### PR TITLE
Support multiple time-of-use rates with day-of-week selection

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -33,7 +33,7 @@ export default function App() {
     setNeedsCsvConfirm(csv.needsConfirmation);
 
     // Parse PDF if provided
-    let tariff = { retailer: "", plan: "", dailyCharge: null, peakRate: null, offPeakRate: null };
+    let tariff = { retailer: "", plan: "", dailyCharge: null, peakRate: null, offPeakRate: null, baseRate: null };
     if (pdfBuffer) {
       tariff = await extractTariffFromPDF(pdfBuffer);
     }

--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -1,11 +1,97 @@
 import {
   LineChart, Line, AreaChart, Area, BarChart, Bar,
   XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer,
+  ReferenceArea,
 } from "recharts";
 import {
   dailyProfile, seasonalProfiles, weeklyTrend,
   generateInsights, currentAnnualCost, rankPlans,
 } from "../utils/analysis.js";
+
+// Palette of semi-transparent colours for TOU background bands
+const TOU_COLORS = [
+  "rgba(249, 115, 22, 0.13)",  // orange
+  "rgba(139, 92, 246, 0.13)",  // purple
+  "rgba(20, 184, 166, 0.13)",  // teal
+  "rgba(236, 72, 153, 0.13)",  // pink
+];
+
+const TOU_STROKE_COLORS = [
+  "#f97316",
+  "#8b5cf6",
+  "#14b8a6",
+  "#ec4899",
+];
+
+const DAY_NAMES = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+
+/**
+ * Convert an hour number (0–23) to the "HH:00" format used as the x-axis dataKey.
+ */
+function hourToKey(h) {
+  return `${String(h).padStart(2, "0")}:00`;
+}
+
+/**
+ * Build <ReferenceArea> elements for the TOU rates.
+ * Each TOU band spans from startHour to endHour on the half-hour x-axis.
+ * Overnight ranges (e.g. 21–7) are split into two bands: start→23:30 and 00:00→end.
+ */
+function touReferenceAreas(touRates) {
+  if (!touRates || touRates.length === 0) return null;
+
+  const areas = [];
+  touRates.forEach((tou, idx) => {
+    const color = TOU_COLORS[idx % TOU_COLORS.length];
+    const stroke = TOU_STROKE_COLORS[idx % TOU_STROKE_COLORS.length];
+    const daysLabel = tou.days.length === 7
+      ? "All days"
+      : tou.days.map((d) => DAY_NAMES[d]).join(", ");
+    const label = `${tou.rate}c — ${daysLabel}`;
+
+    const startKey = hourToKey(tou.startHour);
+    const endKey = hourToKey(tou.endHour);
+
+    if (tou.startHour < tou.endHour) {
+      // Normal range (e.g. 7–21)
+      areas.push(
+        <ReferenceArea
+          key={`tou-${idx}`}
+          x1={startKey}
+          x2={endKey}
+          fill={color}
+          stroke={stroke}
+          strokeOpacity={0.3}
+          label={{ value: label, position: "insideTop", fontSize: 11, fill: stroke }}
+        />
+      );
+    } else if (tou.startHour > tou.endHour) {
+      // Overnight range (e.g. 21–7) → split into two bands
+      areas.push(
+        <ReferenceArea
+          key={`tou-${idx}-a`}
+          x1={startKey}
+          x2="23:30"
+          fill={color}
+          stroke={stroke}
+          strokeOpacity={0.3}
+          label={{ value: label, position: "insideTop", fontSize: 11, fill: stroke }}
+        />
+      );
+      areas.push(
+        <ReferenceArea
+          key={`tou-${idx}-b`}
+          x1="00:00"
+          x2={endKey}
+          fill={color}
+          stroke={stroke}
+          strokeOpacity={0.3}
+        />
+      );
+    }
+  });
+  return areas;
+}
 
 /**
  * Main analysis dashboard — charts, insights, and plan comparison table.
@@ -28,6 +114,8 @@ export default function Dashboard({ data, currentTariff }) {
   // Only show every 4th x-axis label to avoid crowding
   const tickFilter = (_, i) => i % 4 === 0;
 
+  const touAreas = touReferenceAreas(currentTariff.touRates);
+
   return (
     <div className="dashboard">
       <h2>Analysis Dashboard</h2>
@@ -45,12 +133,34 @@ export default function Dashboard({ data, currentTariff }) {
         <ResponsiveContainer width="100%" height={300}>
           <AreaChart data={profile}>
             <CartesianGrid strokeDasharray="3 3" />
+            {touAreas}
             <XAxis dataKey="hour" tickFormatter={(v, i) => tickFilter(v, i) ? v : ""} />
             <YAxis unit=" kWh" />
             <Tooltip />
             <Area type="monotone" dataKey="kwh" stroke="#3b82f6" fill="#93c5fd" name="Avg kWh" />
           </AreaChart>
         </ResponsiveContainer>
+        {currentTariff.touRates && currentTariff.touRates.length > 0 && (
+          <div className="tou-legend">
+            {currentTariff.touRates.map((tou, idx) => (
+              <span key={idx} className="tou-legend-item">
+                <span
+                  className="tou-legend-swatch"
+                  style={{ background: TOU_STROKE_COLORS[idx % TOU_STROKE_COLORS.length] }}
+                />
+                {tou.rate}c/kWh ({tou.startHour}:00–{tou.endHour}:00,{" "}
+                {tou.days.length === 7
+                  ? "all days"
+                  : tou.days.map((d) => DAY_NAMES[d]).join(", ")}
+                )
+              </span>
+            ))}
+            <span className="tou-legend-item">
+              <span className="tou-legend-swatch" style={{ background: "#94a3b8" }} />
+              Base rate: {currentTariff.baseRate}c/kWh
+            </span>
+          </div>
+        )}
       </section>
 
       {/* ── Seasonal Comparison ── */}
@@ -60,6 +170,7 @@ export default function Dashboard({ data, currentTariff }) {
         <ResponsiveContainer width="100%" height={300}>
           <LineChart data={seasonalMerged}>
             <CartesianGrid strokeDasharray="3 3" />
+            {touAreas}
             <XAxis dataKey="hour" tickFormatter={(v, i) => tickFilter(v, i) ? v : ""} />
             <YAxis unit=" kWh" />
             <Tooltip />
@@ -68,6 +179,27 @@ export default function Dashboard({ data, currentTariff }) {
             <Line type="monotone" dataKey="winter" stroke="#3b82f6" name="Winter" dot={false} />
           </LineChart>
         </ResponsiveContainer>
+        {currentTariff.touRates && currentTariff.touRates.length > 0 && (
+          <div className="tou-legend">
+            {currentTariff.touRates.map((tou, idx) => (
+              <span key={idx} className="tou-legend-item">
+                <span
+                  className="tou-legend-swatch"
+                  style={{ background: TOU_STROKE_COLORS[idx % TOU_STROKE_COLORS.length] }}
+                />
+                {tou.rate}c/kWh ({tou.startHour}:00–{tou.endHour}:00,{" "}
+                {tou.days.length === 7
+                  ? "all days"
+                  : tou.days.map((d) => DAY_NAMES[d]).join(", ")}
+                )
+              </span>
+            ))}
+            <span className="tou-legend-item">
+              <span className="tou-legend-swatch" style={{ background: "#94a3b8" }} />
+              Base rate: {currentTariff.baseRate}c/kWh
+            </span>
+          </div>
+        )}
       </section>
 
       {/* ── Weekly Trend ── */}

--- a/src/components/TariffReview.jsx
+++ b/src/components/TariffReview.jsx
@@ -1,33 +1,79 @@
 import { useState } from "react";
 
+const DAY_LABELS = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
+// JS getDay(): 0=Sun,1=Mon,...,6=Sat  →  our checkbox index: 0=Mon,...,6=Sun
+const DAY_INDEX_TO_JS = [1, 2, 3, 4, 5, 6, 0];
+
+function emptyTouRate() {
+  return { rate: "", startHour: 7, endHour: 21, days: [1, 2, 3, 4, 5, 6, 0] };
+}
+
 /**
  * Tariff review screen — shows extracted tariff values and lets the user edit them.
  * extractedTariff: { retailer, plan, dailyCharge, peakRate, offPeakRate }
  * onConfirm(tariff): called with the confirmed/edited tariff.
  */
 export default function TariffReview({ extractedTariff, onConfirm, csvWarnings, csvPreview, onConfirmCsv }) {
+  // Migrate old off-peak into a TOU rate entry if present
+  const initialTouRates =
+    extractedTariff.offPeakRate
+      ? [{ rate: extractedTariff.offPeakRate, startHour: 21, endHour: 7, days: [1, 2, 3, 4, 5, 6, 0] }]
+      : [];
+
   const [tariff, setTariff] = useState({
     retailer: extractedTariff.retailer || "",
     plan: extractedTariff.plan || "",
     dailyCharge: extractedTariff.dailyCharge ?? "",
-    peakRate: extractedTariff.peakRate ?? "",
-    offPeakRate: extractedTariff.offPeakRate ?? "",
-    peakStart: 7,
-    peakEnd: 21,
+    baseRate: extractedTariff.peakRate ?? "",
   });
+
+  const [touRates, setTouRates] = useState(initialTouRates);
 
   const update = (field) => (e) =>
     setTariff((t) => ({ ...t, [field]: e.target.value }));
+
+  const updateTou = (index, field) => (e) => {
+    setTouRates((prev) => {
+      const next = [...prev];
+      next[index] = { ...next[index], [field]: e.target.value };
+      return next;
+    });
+  };
+
+  const toggleTouDay = (index, dayJs) => {
+    setTouRates((prev) => {
+      const next = [...prev];
+      const entry = { ...next[index] };
+      const days = [...entry.days];
+      if (days.includes(dayJs)) {
+        entry.days = days.filter((d) => d !== dayJs);
+      } else {
+        entry.days = [...days, dayJs];
+      }
+      next[index] = entry;
+      return next;
+    });
+  };
+
+  const addTouRate = () => setTouRates((prev) => [...prev, emptyTouRate()]);
+
+  const removeTouRate = (index) =>
+    setTouRates((prev) => prev.filter((_, i) => i !== index));
 
   const handleConfirm = () => {
     onConfirm({
       retailer: tariff.retailer,
       plan: tariff.plan,
       dailyCharge: parseFloat(tariff.dailyCharge) || 0,
-      peakRate: parseFloat(tariff.peakRate) || 0,
-      offPeakRate: parseFloat(tariff.offPeakRate) || 0,
-      peakStart: parseInt(tariff.peakStart) || 7,
-      peakEnd: parseInt(tariff.peakEnd) || 21,
+      baseRate: parseFloat(tariff.baseRate) || 0,
+      touRates: touRates
+        .filter((t) => t.rate !== "" && t.rate != null)
+        .map((t) => ({
+          rate: parseFloat(t.rate) || 0,
+          startHour: parseInt(t.startHour) || 0,
+          endHour: parseInt(t.endHour) || 0,
+          days: t.days,
+        })),
     });
   };
 
@@ -36,7 +82,7 @@ export default function TariffReview({ extractedTariff, onConfirm, csvWarnings, 
       <h2>Review Your Current Tariff</h2>
       <p className="subtitle">
         We extracted these values from your bill. Please review and correct any
-        that look wrong. Leave off-peak rate blank if your plan doesn't have one.
+        that look wrong.
       </p>
 
       {/* Show CSV warnings if confirmation needed */}
@@ -84,25 +130,89 @@ export default function TariffReview({ extractedTariff, onConfirm, csvWarnings, 
           <input type="number" value={tariff.dailyCharge} onChange={update("dailyCharge")} placeholder="e.g. 230" />
         </div>
         <div className="form-row">
-          <label>Peak / anytime rate (cents/kWh)</label>
-          <input type="number" value={tariff.peakRate} onChange={update("peakRate")} placeholder="e.g. 28.5" />
+          <label>Base rate (cents/kWh)</label>
+          <input type="number" value={tariff.baseRate} onChange={update("baseRate")} placeholder="e.g. 28.5" />
         </div>
-        <div className="form-row">
-          <label>Off-peak rate (cents/kWh, leave blank if N/A)</label>
-          <input type="number" value={tariff.offPeakRate} onChange={update("offPeakRate")} placeholder="e.g. 15" />
+
+        {/* ── Time-of-Use Rates ── */}
+        <div className="tou-section">
+          <h3>Time of Use Rates</h3>
+          <p className="tou-hint">
+            Add rates that apply during specific hours and days. The base rate
+            applies to any time not covered below.
+          </p>
+
+          {touRates.map((tou, idx) => (
+            <div className="tou-entry" key={idx}>
+              <div className="tou-header">
+                <span className="tou-label">Rate {idx + 1}</span>
+                <button
+                  className="tou-remove-btn"
+                  type="button"
+                  onClick={() => removeTouRate(idx)}
+                >
+                  Remove
+                </button>
+              </div>
+
+              <div className="form-row">
+                <label>Rate (cents/kWh)</label>
+                <input
+                  type="number"
+                  value={tou.rate}
+                  onChange={updateTou(idx, "rate")}
+                  placeholder="e.g. 15"
+                />
+              </div>
+
+              <div className="form-row-inline">
+                <div>
+                  <label>Start hour (0–23)</label>
+                  <input
+                    type="number"
+                    min="0"
+                    max="23"
+                    value={tou.startHour}
+                    onChange={updateTou(idx, "startHour")}
+                  />
+                </div>
+                <div>
+                  <label>End hour (0–23)</label>
+                  <input
+                    type="number"
+                    min="0"
+                    max="23"
+                    value={tou.endHour}
+                    onChange={updateTou(idx, "endHour")}
+                  />
+                </div>
+              </div>
+
+              <div className="tou-days">
+                <label>Applies on:</label>
+                <div className="day-checkboxes">
+                  {DAY_LABELS.map((label, di) => {
+                    const jsDay = DAY_INDEX_TO_JS[di];
+                    return (
+                      <label key={di} className="day-checkbox">
+                        <input
+                          type="checkbox"
+                          checked={tou.days.includes(jsDay)}
+                          onChange={() => toggleTouDay(idx, jsDay)}
+                        />
+                        {label}
+                      </label>
+                    );
+                  })}
+                </div>
+              </div>
+            </div>
+          ))}
+
+          <button className="secondary-btn" type="button" onClick={addTouRate}>
+            + Add Time of Use Rate
+          </button>
         </div>
-        {tariff.offPeakRate && (
-          <div className="form-row-inline">
-            <div>
-              <label>Peak starts (hour, 0–23)</label>
-              <input type="number" min="0" max="23" value={tariff.peakStart} onChange={update("peakStart")} />
-            </div>
-            <div>
-              <label>Peak ends (hour, 0–23)</label>
-              <input type="number" min="0" max="23" value={tariff.peakEnd} onChange={update("peakEnd")} />
-            </div>
-          </div>
-        )}
       </div>
 
       <button className="primary-btn" onClick={handleConfirm}>

--- a/src/index.css
+++ b/src/index.css
@@ -243,6 +243,118 @@ h3 {
   box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.15);
 }
 
+/* ── Time-of-Use Section ──────────────────────────────── */
+.tou-section {
+  margin-top: 0.5rem;
+}
+
+.tou-section h3 {
+  margin-bottom: 0.25rem;
+}
+
+.tou-hint {
+  font-size: 0.85rem;
+  color: #94a3b8;
+  margin-bottom: 1rem;
+}
+
+.tou-entry {
+  border: 1px solid #e2e8f0;
+  border-radius: 8px;
+  padding: 1rem;
+  margin-bottom: 0.75rem;
+  background: #f8fafc;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.tou-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.tou-label {
+  font-weight: 600;
+  font-size: 0.9rem;
+  color: #334155;
+}
+
+.tou-remove-btn {
+  background: none;
+  border: 1px solid #fca5a5;
+  color: #dc2626;
+  border-radius: 6px;
+  padding: 0.25rem 0.75rem;
+  font-size: 0.8rem;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.tou-remove-btn:hover {
+  background: #fef2f2;
+}
+
+.tou-days {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.tou-days > label {
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #475569;
+}
+
+.day-checkboxes {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.day-checkbox {
+  display: flex;
+  align-items: center;
+  gap: 0.3rem;
+  font-size: 0.85rem;
+  color: #334155;
+  cursor: pointer;
+  user-select: none;
+}
+
+.day-checkbox input[type="checkbox"] {
+  accent-color: #3b82f6;
+  cursor: pointer;
+}
+
+/* ── TOU Chart Legend ─────────────────────────────────── */
+.tou-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-top: 0.75rem;
+  padding-top: 0.5rem;
+  border-top: 1px solid #f1f5f9;
+}
+
+.tou-legend-item {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: 0.8rem;
+  color: #475569;
+}
+
+.tou-legend-swatch {
+  display: inline-block;
+  width: 12px;
+  height: 12px;
+  border-radius: 2px;
+  flex-shrink: 0;
+}
+
 /* ── Warning Box ───────────────────────────────────────── */
 .warning-box {
   background: #fefce8;

--- a/src/utils/analysis.js
+++ b/src/utils/analysis.js
@@ -142,8 +142,8 @@ export function generateInsights(data, currentTariff) {
       text: `Average daily consumption: ${avgSummerDay.toFixed(1)} kWh (summer) vs ${avgWinterDay.toFixed(1)} kWh (winter). Winter is ${diff > 0 ? `${diff.toFixed(1)} kWh higher (+${pct}%)` : `${Math.abs(diff).toFixed(1)} kWh lower`}, suggesting ${diff > 3 ? "significant heating costs — consider insulation or a heat pump if you don't already have one." : diff > 0 ? "moderate heating-related usage." : "minimal heating impact."}`,
     });
 
-    if (diff > 0 && currentTariff.peakRate) {
-      const heatingCostPerYear = (diff * 182 * currentTariff.peakRate) / 100; // 182 winter days
+    if (diff > 0 && currentTariff.baseRate) {
+      const heatingCostPerYear = (diff * 182 * currentTariff.baseRate) / 100; // 182 winter days
       insights.push({
         type: "seasonal_cost",
         text: `Estimated winter heating spend: ~$${heatingCostPerYear.toFixed(0)}/year based on the seasonal difference.`,
@@ -170,22 +170,32 @@ export function generateInsights(data, currentTariff) {
   }
 
   // 4. Load-shifting savings opportunity
-  if (currentTariff.peakRate && currentTariff.offPeakRate) {
-    // Calculate how much daytime (7am–9pm) consumption could be shifted
-    const peakData = data.filter((d) => hour(d.timestamp) >= 7 && hour(d.timestamp) < 21);
-    const totalPeakKwh = peakData.reduce((s, d) => s + d.kwh, 0);
+  const touRates = currentTariff.touRates || [];
+  if (currentTariff.baseRate && touRates.length > 0) {
+    // Find the cheapest TOU rate
+    const cheapestTou = touRates.reduce((min, t) => (t.rate < min.rate ? t : min), touRates[0]);
+    const rateDiff = currentTariff.baseRate - cheapestTou.rate;
 
-    // Assume 20% could be realistically shifted
-    const shiftableKwh = totalPeakKwh * 0.2;
-    const rateDiff = currentTariff.peakRate - currentTariff.offPeakRate;
-    const daysInData = allDays.length;
-    const annualSaving = (shiftableKwh / daysInData) * 365 * rateDiff / 100;
-
-    if (annualSaving > 10) {
-      insights.push({
-        type: "load_shifting",
-        text: `If you shifted ~20% of your daytime usage to off-peak hours (${Math.round(shiftableKwh / daysInData * 365)} kWh/year), you could save approximately $${annualSaving.toFixed(0)}/year at current rates.`,
+    if (rateDiff > 0) {
+      // Calculate consumption during base-rate hours (not covered by any TOU)
+      const baseRateData = data.filter((d) => {
+        const h = hour(d.timestamp);
+        const dow = d.timestamp.getDay();
+        return !touRates.some((tou) => matchesTou(h, dow, tou));
       });
+      const totalBaseKwh = baseRateData.reduce((s, d) => s + d.kwh, 0);
+
+      // Assume 20% could be realistically shifted
+      const shiftableKwh = totalBaseKwh * 0.2;
+      const daysInData = allDays.length;
+      const annualSaving = (shiftableKwh / daysInData) * 365 * rateDiff / 100;
+
+      if (annualSaving > 10) {
+        insights.push({
+          type: "load_shifting",
+          text: `If you shifted ~20% of your base-rate usage to cheaper time-of-use hours (${Math.round(shiftableKwh / daysInData * 365)} kWh/year), you could save approximately $${annualSaving.toFixed(0)}/year at current rates.`,
+        });
+      }
     }
   }
 
@@ -268,8 +278,24 @@ export function annualCost(data, plan) {
 }
 
 /**
+ * Check whether a given hour + day-of-week falls within a TOU rate period.
+ * Handles overnight ranges (e.g. startHour 21, endHour 7).
+ */
+export function matchesTou(h, dayOfWeek, tou) {
+  if (!tou.days.includes(dayOfWeek)) return false;
+  const { startHour, endHour } = tou;
+  if (startHour > endHour) {
+    return h >= startHour || h < endHour;
+  } else if (startHour < endHour) {
+    return h >= startHour && h < endHour;
+  }
+  return false; // startHour === endHour → zero-width window
+}
+
+/**
  * Compute estimated annual cost for the user's current tariff.
- * currentTariff: { dailyCharge, peakRate, offPeakRate, peakStart, peakEnd } in cents.
+ * currentTariff: { dailyCharge, baseRate, touRates: [{ rate, startHour, endHour, days }] }
+ * All monetary values in cents.
  */
 export function currentAnnualCost(data, ct) {
   const first = data[0].timestamp;
@@ -279,20 +305,19 @@ export function currentAnnualCost(data, ct) {
 
   const scaleFactor = 365 / days;
   const fixedCost = ((ct.dailyCharge || 0) / 100) * 365;
+  const touRates = ct.touRates || [];
 
   let energyCost = 0;
   for (const d of data) {
     const h = hour(d.timestamp);
-    let rate = ct.peakRate || 0;
+    const dow = d.timestamp.getDay(); // 0=Sun … 6=Sat
+    let rate = ct.baseRate || 0;
 
-    // If off-peak rate is set and we have peak hours, use TOU logic
-    if (ct.offPeakRate && ct.peakStart !== undefined && ct.peakEnd !== undefined) {
-      const start = ct.peakStart;
-      const end = ct.peakEnd;
-      if (start > end) {
-        rate = (h >= start || h < end) ? ct.peakRate : ct.offPeakRate;
-      } else {
-        rate = (h >= start && h < end) ? ct.peakRate : ct.offPeakRate;
+    // First matching TOU rate wins
+    for (const tou of touRates) {
+      if (matchesTou(h, dow, tou)) {
+        rate = tou.rate;
+        break;
       }
     }
 


### PR DESCRIPTION
- Rename "Peak / anytime rate" to "Base rate" in tariff form
- Replace single off-peak rate with multiple TOU rate entries, each with rate, start/end hour, and day-of-week checkboxes (all selected by default)
- Update currentAnnualCost() to match readings against TOU rates by both hour and day-of-week, falling back to base rate when no TOU matches
- Update load-shifting insight to work with the new TOU structure
- Add ReferenceArea background bands on the Average Daily Profile and Summer vs Winter Profile charts to visualize TOU time windows
- Add TOU legend below both charts showing rates and applicable days
- Add CSS for TOU form entries, day checkboxes, and chart legend

https://claude.ai/code/session_013ykMKRMQE6zZnN93TZBD85