### PR TITLE
Simplify night load options with diversity-adjusted fixed values

### DIFF
--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -102,17 +102,13 @@ function touReferenceAreas(touRates) {
 export default function Dashboard({ data, currentTariff }) {
   const [expandedRow, setExpandedRow] = useState(null);
   const [nightEv, setNightEv] = useState(false);
-  const [evPowerW, setEvPowerW] = useState(2000);
   const [nightHotWater, setNightHotWater] = useState(false);
   const [nightBattery, setNightBattery] = useState(false);
-  const [batteryPowerW, setBatteryPowerW] = useState(2000);
 
   const nightLoadOptions = {
     ev: nightEv,
-    evPowerW,
     hotWater: nightHotWater,
     battery: nightBattery,
-    batteryPowerW,
   };
 
   const profile = dailyProfile(data);
@@ -258,23 +254,6 @@ export default function Dashboard({ data, currentTariff }) {
                       <input type="checkbox" checked={nightEv} onChange={(e) => setNightEv(e.target.checked)} />
                       I have an EV which I charge overnight
                     </label>
-                    {nightEv && (
-                      <div className="baseload-followup">
-                        <p className="followup-label">What is the EV charger power?</p>
-                        <label className="baseload-radio">
-                          <input type="radio" name="evPower" checked={evPowerW === 2000} onChange={() => setEvPowerW(2000)} />
-                          Plug into the wall max 10A (2kW)
-                        </label>
-                        <label className="baseload-radio">
-                          <input type="radio" name="evPower" checked={evPowerW === 7000} onChange={() => setEvPowerW(7000)} />
-                          Fast charger (7kW)
-                        </label>
-                        <label className="baseload-radio">
-                          <input type="radio" name="evPower" checked={evPowerW === 10000} onChange={() => setEvPowerW(10000)} />
-                          Greater than 7kW
-                        </label>
-                      </div>
-                    )}
 
                     <label className="baseload-checkbox">
                       <input type="checkbox" checked={nightHotWater} onChange={(e) => setNightHotWater(e.target.checked)} />
@@ -285,21 +264,9 @@ export default function Dashboard({ data, currentTariff }) {
                       <input type="checkbox" checked={nightBattery} onChange={(e) => setNightBattery(e.target.checked)} />
                       I have a battery that charges at night
                     </label>
-                    {nightBattery && (
-                      <div className="baseload-followup">
-                        <p className="followup-label">What is your battery charge rate?</p>
-                        <div className="battery-slider">
-                          <input
-                            type="range"
-                            min={1000}
-                            max={5000}
-                            step={500}
-                            value={batteryPowerW}
-                            onChange={(e) => setBatteryPowerW(Number(e.target.value))}
-                          />
-                          <span className="slider-value">{(batteryPowerW / 1000).toFixed(1)} kW</span>
-                        </div>
-                      </div>
+
+                    {(nightEv || nightHotWater || nightBattery) && !ins.isHighBaseload && (
+                      <p className="baseload-resolved">After factoring in these loads, the nighttime baseload looks normal.</p>
                     )}
                   </div>
                 )}

--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -268,6 +268,9 @@ export default function Dashboard({ data, currentTariff }) {
                     {(nightEv || nightHotWater || nightBattery) && !ins.isHighBaseload && (
                       <p className="baseload-resolved">After factoring in these loads, the nighttime baseload looks normal.</p>
                     )}
+                    {(nightEv || nightHotWater || nightBattery) && ins.isHighBaseload && (
+                      <p className="baseload-still-high">After factoring in these loads, the nighttime baseload still looks higher than usual (~{(ins.adjustedBaseloadW / 1000).toFixed(1)} kW). Common culprits are fridges, freezers, hot water cylinders, pools, spas, and leaking hot water pipes.</p>
+                    )}
                   </div>
                 )}
               </li>

--- a/src/index.css
+++ b/src/index.css
@@ -800,6 +800,17 @@ h3 {
   color: #166534;
 }
 
+.baseload-still-high {
+  margin-top: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  background: #fef2f2;
+  border-left: 3px solid #ef4444;
+  border-radius: var(--radius-sm);
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #991b1b;
+}
+
 /* ── Plan Comparison Table ────────────────────────────── */
 .plans-section {
   background: #fff;

--- a/src/index.css
+++ b/src/index.css
@@ -789,52 +789,15 @@ h3 {
   height: 16px;
 }
 
-.baseload-followup {
-  margin-left: 1.5rem;
-  margin-top: 0.25rem;
-  margin-bottom: 0.5rem;
+.baseload-resolved {
+  margin-top: 0.5rem;
   padding: 0.5rem 0.75rem;
-  background: rgba(255, 255, 255, 0.6);
+  background: #f0fdf4;
+  border-left: 3px solid #22c55e;
   border-radius: var(--radius-sm);
-  border: 1px solid rgba(0, 0, 0, 0.06);
-}
-
-.followup-label {
-  font-size: 0.8rem;
-  font-weight: 500;
-  color: #374151;
-  margin-bottom: 0.35rem;
-}
-
-.baseload-radio {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  font-size: 0.82rem;
-  cursor: pointer;
-  padding: 0.15rem 0;
-}
-
-.baseload-radio input[type="radio"] {
-  accent-color: var(--coral-500);
-}
-
-.battery-slider {
-  display: flex;
-  align-items: center;
-  gap: 0.75rem;
-}
-
-.battery-slider input[type="range"] {
-  flex: 1;
-  accent-color: var(--coral-500);
-}
-
-.slider-value {
-  font-weight: 600;
   font-size: 0.85rem;
-  min-width: 3rem;
-  color: var(--coral-600);
+  font-weight: 500;
+  color: #166534;
 }
 
 /* ── Plan Comparison Table ────────────────────────────── */

--- a/src/utils/analysis.js
+++ b/src/utils/analysis.js
@@ -111,11 +111,11 @@ export function generateInsights(data, currentTariff, nightLoadOptions = {}) {
     : 0;
   const nightBaseloadW = Math.round(avgNightKwh * 2 * 1000); // Convert half-hourly kWh to watts
 
-  // Subtract known night loads from the baseload
+  // Subtract known night loads from the baseload (diversity-adjusted averages)
   let knownLoadW = 0;
-  if (nightLoadOptions.ev) knownLoadW += nightLoadOptions.evPowerW || 2000;
-  if (nightLoadOptions.hotWater) knownLoadW += 2000;
-  if (nightLoadOptions.battery) knownLoadW += nightLoadOptions.batteryPowerW || 2000;
+  if (nightLoadOptions.ev) knownLoadW += 1000;        // ~1kW avg accounts for not charging every night
+  if (nightLoadOptions.hotWater) knownLoadW += 500;    // ~0.5kW avg for timer-controlled HWC
+  if (nightLoadOptions.battery) knownLoadW += 2000;    // ~2kW typical home battery charge rate
 
   const adjustedBaseloadW = Math.max(0, nightBaseloadW - knownLoadW);
   const hasKnownLoads = knownLoadW > 0;

--- a/src/utils/analysis.js
+++ b/src/utils/analysis.js
@@ -139,6 +139,7 @@ export function generateInsights(data, currentTariff, nightLoadOptions = {}) {
     type: "baseload",
     isHighBaseload: hasKnownLoads ? isHighAdjusted : isHighRaw,
     rawBaseloadW: nightBaseloadW,
+    adjustedBaseloadW,
     text: baseloadText,
   });
 


### PR DESCRIPTION
Use fixed diversity-adjusted constants instead of user-configurable power levels: EV charging at 1kW (accounts for not charging every night), hot water at 0.5kW, battery at 2kW. Removes radio buttons and slider. Shows green "After factoring in these loads, the nighttime baseload looks normal" message when selected loads explain the high baseload.

https://claude.ai/code/session_01MsM6uxU2gtj2TCevqNT6Zb