### PR TITLE
Convert profile graphs from kWh per half-hour to kWh/h

### DIFF
--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -145,15 +145,15 @@ export default function Dashboard({ data, currentTariff }) {
         {/* ── Average Daily Profile ── */}
         <section className="chart-section card-coral">
           <h3>Average Daily Consumption Profile</h3>
-          <p className="chart-desc">Average kWh per half-hour interval across the full dataset.</p>
+          <p className="chart-desc">Average kWh/h across the full dataset.</p>
           <ResponsiveContainer width="100%" height={300}>
             <AreaChart data={profile}>
               <CartesianGrid strokeDasharray="3 3" />
               {touAreas}
               <XAxis dataKey="hour" tickFormatter={(v, i) => tickFilter(v, i) ? v : ""} />
-              <YAxis unit=" kWh" />
+              <YAxis unit=" kWh/h" />
               <Tooltip />
-              <Area type="monotone" dataKey="kwh" stroke="#ff6b5b" fill="#ffc9c2" name="Avg kWh" />
+              <Area type="monotone" dataKey="kwh" stroke="#ff6b5b" fill="#ffc9c2" name="Avg kWh/h" />
             </AreaChart>
           </ResponsiveContainer>
           {currentTariff.touRates && currentTariff.touRates.length > 0 && (
@@ -188,11 +188,11 @@ export default function Dashboard({ data, currentTariff }) {
               <CartesianGrid strokeDasharray="3 3" />
               {touAreas}
               <XAxis dataKey="hour" tickFormatter={(v, i) => tickFilter(v, i) ? v : ""} />
-              <YAxis unit=" kWh" />
+              <YAxis unit=" kWh/h" />
               <Tooltip />
               <Legend />
-              <Line type="monotone" dataKey="summer" stroke="#ff8a7a" name="Summer" dot={false} />
-              <Line type="monotone" dataKey="winter" stroke="#3b82f6" name="Winter" dot={false} />
+              <Line type="monotone" dataKey="summer" stroke="#ff8a7a" name="Summer (kWh/h)" dot={false} />
+              <Line type="monotone" dataKey="winter" stroke="#3b82f6" name="Winter (kWh/h)" dot={false} />
             </LineChart>
           </ResponsiveContainer>
           {currentTariff.touRates && currentTariff.touRates.length > 0 && (

--- a/src/utils/analysis.js
+++ b/src/utils/analysis.js
@@ -47,7 +47,7 @@ export function dailyProfile(data) {
   return buckets.map((b, i) => ({
     slot: i,
     hour: `${String(Math.floor(i / 2)).padStart(2, "0")}:${i % 2 === 0 ? "00" : "30"}`,
-    kwh: b.count > 0 ? Math.round((b.total / b.count) * 1000) / 1000 : 0,
+    kwh: b.count > 0 ? Math.round((b.total / b.count) * 2 * 1000) / 1000 : 0,
   }));
 }
 
@@ -72,7 +72,7 @@ export function seasonalProfiles(data) {
     buckets.map((b, i) => ({
       slot: i,
       hour: `${String(Math.floor(i / 2)).padStart(2, "0")}:${i % 2 === 0 ? "00" : "30"}`,
-      kwh: b.count > 0 ? Math.round((b.total / b.count) * 1000) / 1000 : 0,
+      kwh: b.count > 0 ? Math.round((b.total / b.count) * 2 * 1000) / 1000 : 0,
     }));
 
   return { summer: format(summer), winter: format(winter) };


### PR DESCRIPTION
## Summary\n- Double the computed values in `dailyProfile()` and `seasonalProfiles()` to convert from kWh per 30-min interval to kWh per hour\n- Update y-axis units from `kWh` to `kWh/h` on both the Average Daily Consumption Profile and Summer vs Winter Profile charts\n- Update chart descriptions and legend labels to reflect the new unit\n\nThis makes the graphs display kWh/h (essentially kW), which is cleaner and more standard.\n\nFixes #18\n\nhttps://claude.ai/code/session_019ckYjevW3nvnPwVuSavdUo