### PR TITLE
Add solar export, battery ROI, and solar-installation ROI

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ A browser-based tool that analyses New Zealand residential electricity consumpti
 - **PDF Bill Parsing** — Extracts your current tariff details (daily charge, peak/off-peak rates) from uploaded electricity bills using pdf.js with line-aware text reconstruction.
 - **Consumption Analysis** — Average daily profile (48 half-hour slots), summer vs winter comparison, and weekly trends.
 - **Smart Insights** — Nighttime baseload detection, seasonal heating cost estimates, usage spike alerts, solar pattern recognition, and load-shifting savings opportunities.
+- **Solar Export & Battery ROI** — Captures two-way energy flows (a dedicated export column or negative readings), reads a solar export/buy-back rate from your bill, and models the discounted payback of an 8 kWh battery that time-shifts daytime export to your after-sunset load.
+- **Solar Installation ROI** — For households without solar, models 5 / 8.5 / 10 kW systems against your actual usage using average NZ generation, ranks them by discounted payback, suggests load-shifting where it would tip the economics, and tests whether adding a battery improves the case.
 - **Plan Comparison** — Ranks plans from Mercury, Meridian, Genesis, Contact, Electric Kiwi, Octopus, Nova, Pulse, and Powershop by estimated annual cost, accounting for time-of-use rates, day-of-week restrictions, and free-power windows.
 
 ## Getting Started
@@ -72,6 +74,15 @@ Auto-detects and normalises half-hourly electricity data from multiple CSV forma
 #### `src/utils/pdfParser.js` — PDF Tariff Extractor
 
 Extracts tariff rates from electricity bill PDFs using pdf.js. Uses Y-coordinate grouping to reconstruct table rows, then applies keyword-based line classification (daily charge, peak, off-peak) with rate extraction. Falls back to keyword-proximity search for values the line scanner misses.
+
+#### `src/utils/solar.js` — Solar & Battery Economics
+
+Two ROI models for two-way energy flows:
+
+- `batteryROI(data, tariff)` — for households **already exporting** solar. Simulates an 8 kWh battery day-by-day: it charges from each day's export and discharges against after-sunset load (with leftover charge carried to the next day). The saving on each shifted kWh is the gap between the grid buy rate at the time of use and the export rate forgone. Skips when export data covers only one season; otherwise annualises and returns a discounted payback and a recommend / consider / uneconomic verdict.
+- `solarROI(data, tariff)` — for households **without** solar. Models 5 / 8.5 / 10 kW systems from average NZ sun-hours, compares generation to actual half-hourly load (self-consumption vs export), ranks scenarios by discounted payback, estimates the load-shift needed to reach a 10-year payback, and runs `batteryROI` on the modelled post-solar profile to test battery pairing.
+
+Financial and physical assumptions (5% discount rate, NZ sun-hours by month, installed capex per system size, battery cost) are named constants at the top of the file with a `SOLAR_DATA_LAST_UPDATED` marker. As with `tariffs.js`, these are representative figures — verify against quotes for your roof and location.
 
 #### `src/utils/excelParser.js` — Excel Converter
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -34,7 +34,7 @@ export default function App() {
     setNeedsCsvConfirm(csv.needsConfirmation);
 
     // Parse PDF if provided
-    let tariff = { dailyCharge: null, peakRate: null, offPeakRate: null, baseRate: null };
+    let tariff = { dailyCharge: null, peakRate: null, offPeakRate: null, baseRate: null, solarExportRate: null };
     if (pdfBuffer) {
       tariff = await extractTariffFromPDF(pdfBuffer);
     }

--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -8,6 +8,7 @@ import {
   dailyProfile, seasonalProfiles, weeklyTrend,
   generateInsights, currentAnnualCost, rankPlans,
 } from "../utils/analysis.js";
+import { batteryROI, solarROI, DISCOUNT_RATE } from "../utils/solar.js";
 import { tariffsLastUpdated } from "../tariffs.js";
 import StepIndicator from "./StepIndicator.jsx";
 
@@ -117,6 +118,14 @@ export default function Dashboard({ data, currentTariff, onStepClick }) {
   const myCost = currentAnnualCost(data, currentTariff);
   const insights = generateInsights(data, currentTariff, nightLoadOptions);
   const plans = rankPlans(data, myCost);
+
+  // Two-way energy flows: households already exporting solar get a battery
+  // assessment (issue #36); everyone else gets a "should I install solar?"
+  // assessment (issue #37).
+  const totalExportKwh = data.reduce((s, d) => s + (d.exportKwh || 0), 0);
+  const hasSolar = totalExportKwh > 1;
+  const battery = hasSolar ? batteryROI(data, currentTariff) : null;
+  const solar = hasSolar ? null : solarROI(data, currentTariff);
 
   // Merge seasonal data for the overlay chart
   const seasonalMerged = profile.map((_, i) => ({
@@ -291,6 +300,128 @@ export default function Dashboard({ data, currentTariff, onStepClick }) {
             ))}
           </ul>
         </section>
+
+        {/* ── Battery Assessment (existing solar exporters — issue #36) ── */}
+        {battery && (
+          <section className="solar-section card-coral">
+            <h3>Battery Storage Assessment</h3>
+            {!battery.applicable ? (
+              <p className="chart-desc">{battery.reason}</p>
+            ) : (
+              <>
+                <p className="chart-desc">
+                  You exported solar across {battery.monthsCovered} month(s) of
+                  your data. We modelled an {battery.capacityKwh} kWh battery that
+                  stores daytime export and discharges it against your after-sunset
+                  load, carrying any unused charge to the next day.
+                </p>
+                <div className="solar-stats">
+                  <div className="solar-stat">
+                    <span className="solar-stat-label">Annual solar export</span>
+                    <span className="solar-stat-value">{Math.round(battery.annualExportKwh).toLocaleString()} kWh</span>
+                  </div>
+                  <div className="solar-stat">
+                    <span className="solar-stat-label">Energy shifted to evenings</span>
+                    <span className="solar-stat-value">{Math.round(battery.annualDischargeKwh).toLocaleString()} kWh/yr</span>
+                  </div>
+                  <div className="solar-stat">
+                    <span className="solar-stat-label">Estimated annual saving</span>
+                    <span className="solar-stat-value">${Math.round(battery.annualSaving).toLocaleString()}</span>
+                  </div>
+                  <div className="solar-stat">
+                    <span className="solar-stat-label">Battery cost (assumed)</span>
+                    <span className="solar-stat-value">${battery.cost.toLocaleString()}</span>
+                  </div>
+                  <div className="solar-stat">
+                    <span className="solar-stat-label">Discounted payback ({Math.round(DISCOUNT_RATE * 100)}%)</span>
+                    <span className="solar-stat-value">
+                      {battery.paybackYears != null ? `${battery.paybackYears.toFixed(1)} years` : "> 20 years"}
+                    </span>
+                  </div>
+                </div>
+                <p className={`solar-verdict verdict-${battery.recommendation}`}>
+                  {battery.recommendation === "recommend" &&
+                    "Recommended — the payback is under 15 years, so a battery looks worthwhile for your household."}
+                  {battery.recommendation === "consider" &&
+                    "Worth considering — the payback is under 20 years, but you may want to wait for battery prices to fall further before committing."}
+                  {battery.recommendation === "uneconomic" &&
+                    "The economics of a battery don't currently stack up for your household (payback over 20 years). It may still be worth it as a resilience / backup-power measure during outages."}
+                </p>
+              </>
+            )}
+          </section>
+        )}
+
+        {/* ── Solar Installation Assessment (non-exporters — issue #37) ── */}
+        {solar && solar.applicable && (
+          <section className="solar-section card-coral">
+            <h3>Should You Install Solar?</h3>
+            <p className="data-note" style={{ fontSize: "0.85rem", color: "#666", marginBottom: "0.25rem" }}>
+              Generation is modelled from average New Zealand sun-hours; installed
+              costs are from AI web research as of {solar.dataUpdated} and may
+              contain errors. Always get quotes for your specific roof and location.
+            </p>
+            <p className="chart-desc">
+              Modelled against your actual half-hourly usage. Self-consumed solar
+              saves your grid rate (~{Math.round(solar.avgGridRate)}c/kWh); surplus
+              is exported at {solar.exportRate ? `${solar.exportRate}c/kWh` : "your export rate (not set)"}.
+            </p>
+            <div className="table-wrapper">
+              <table className="plans-table">
+                <thead>
+                  <tr>
+                    <th>System</th>
+                    <th>Installed cost</th>
+                    <th>Annual generation</th>
+                    <th>Annual saving</th>
+                    <th>Payback ({Math.round(DISCOUNT_RATE * 100)}%)</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {solar.scenarios.map((s) => (
+                    <tr key={s.sizeKw} className={s.sizeKw === solar.best.sizeKw ? "saving" : ""}>
+                      <td className="retailer">{s.label}{s.sizeKw === solar.best.sizeKw ? " ★" : ""}</td>
+                      <td>${s.capex.toLocaleString()}</td>
+                      <td>{Math.round(s.annualGenerationKwh).toLocaleString()} kWh</td>
+                      <td>${Math.round(s.annualSaving).toLocaleString()}</td>
+                      <td>{s.paybackYears != null ? `${s.paybackYears.toFixed(1)} yrs` : "> 40 yrs"}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+            <p className={`solar-verdict verdict-${solar.recommendation}`}>
+              {solar.recommendation === "recommend" &&
+                `Recommended — the best value is the ${solar.best.label} system, paying back in about ${solar.best.paybackYears.toFixed(1)} years (under 10).`}
+              {solar.recommendation === "marginal" && (
+                <>
+                  At your current usage the best option ({solar.best.label}) pays
+                  back in about {solar.best.paybackYears.toFixed(1)} years.
+                  {solar.loadShift && solar.loadShift.percentOfLoad != null && (
+                    <>
+                      {" "}If you shifted roughly {Math.round(solar.loadShift.percentOfLoad)}% of
+                      your usage into daylight hours, the payback would drop under 10 years
+                      {solar.loadShift.achievable ? "." : " (though that may be more than your surplus generation can cover)."}
+                    </>
+                  )}
+                </>
+              )}
+              {solar.recommendation === "uneconomic" &&
+                `Solar doesn't currently stack up economically for your usage — the best option (${solar.best.label}) takes over 15 years to pay back. This can change as power prices rise or panel costs fall.`}
+            </p>
+            {solar.combined && solar.combined.paybackYears != null && (
+              <p className="solar-pairing chart-desc">
+                Pairing the {solar.best.label} system with an 8 kWh battery would
+                cost about ${solar.combined.capex.toLocaleString()} together and save
+                roughly ${Math.round(solar.combined.annualSaving).toLocaleString()}/year
+                (≈ {solar.combined.paybackYears.toFixed(1)} year payback)
+                {solar.combined.paybackYears < solar.best.paybackYears
+                  ? " — slightly better economics than solar alone."
+                  : " — but it does not improve on solar alone, so the battery is best treated as a resilience add-on."}
+              </p>
+            )}
+          </section>
+        )}
 
         {/* ── Plan Comparison Table ── */}
         <section className="plans-section card-coral">

--- a/src/components/TariffReview.jsx
+++ b/src/components/TariffReview.jsx
@@ -35,6 +35,17 @@ export default function TariffReview({ extractedTariff, confirmedTariff, onConfi
 
   const [touRates, setTouRates] = useState(initialTouRates);
 
+  // Solar export (buy-back) rate, autofilled by the PDF parser when found.
+  const initialExportRate =
+    (confirmedTariff && confirmedTariff.solarExportRate != null
+      ? confirmedTariff.solarExportRate
+      : extractedTariff.solarExportRate) ?? "";
+  const [solarExportRate, setSolarExportRate] = useState(initialExportRate);
+  // Show the field expanded if a rate was detected or previously entered.
+  const [showSolarExport, setShowSolarExport] = useState(
+    initialExportRate !== "" && initialExportRate != null
+  );
+
   const update = (field) => (e) =>
     setTariff((t) => ({ ...t, [field]: e.target.value }));
 
@@ -67,6 +78,10 @@ export default function TariffReview({ extractedTariff, confirmedTariff, onConfi
     setTouRates((prev) => prev.filter((_, i) => i !== index));
 
   const handleConfirm = () => {
+    const exportRate =
+      showSolarExport && solarExportRate !== "" && solarExportRate != null
+        ? parseFloat(solarExportRate) || 0
+        : null;
     onConfirm({
       dailyCharge: parseFloat(tariff.dailyCharge) || 0,
       baseRate: parseFloat(tariff.baseRate) || 0,
@@ -78,6 +93,7 @@ export default function TariffReview({ extractedTariff, confirmedTariff, onConfi
           endHour: parseInt(t.endHour) || 0,
           days: t.days,
         })),
+      solarExportRate: exportRate,
     });
   };
 
@@ -208,6 +224,46 @@ export default function TariffReview({ extractedTariff, confirmedTariff, onConfi
           <button className="secondary-btn" type="button" onClick={addTouRate}>
             + Add Time of Use Rate
           </button>
+        </div>
+
+        {/* ── Solar export (buy-back) rate ── */}
+        <div className="solar-export-section">
+          <h3>Solar Export</h3>
+          {showSolarExport ? (
+            <>
+              <p className="tou-hint">
+                The rate your retailer pays for electricity you export to the
+                grid (cents/kWh). Used to assess solar and battery economics.
+              </p>
+              <div className="form-row">
+                <label>Solar export rate (cents/kWh)</label>
+                <input
+                  type="number"
+                  value={solarExportRate}
+                  onChange={(e) => setSolarExportRate(e.target.value)}
+                  placeholder="e.g. 12.5"
+                />
+              </div>
+              <button
+                className="tou-remove-btn"
+                type="button"
+                onClick={() => {
+                  setShowSolarExport(false);
+                  setSolarExportRate("");
+                }}
+              >
+                Remove
+              </button>
+            </>
+          ) : (
+            <button
+              className="secondary-btn"
+              type="button"
+              onClick={() => setShowSolarExport(true)}
+            >
+              + Add solar export rate
+            </button>
+          )}
         </div>
       </div>
 

--- a/src/index.css
+++ b/src/index.css
@@ -916,6 +916,76 @@ h3 {
   padding: 1.5rem;
 }
 
+/* ── Solar & Battery assessment ───────────────────────── */
+.solar-section {
+  background: #fff;
+  border: 1px solid var(--grey-200);
+  border-top: 3px solid var(--coral-500);
+  border-radius: var(--radius-md);
+  padding: 1.5rem;
+}
+
+.solar-stats {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  margin: 1rem 0;
+}
+
+.solar-stat {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  min-width: 140px;
+  padding: 0.75rem 1rem;
+  background: var(--coral-50);
+  border-radius: var(--radius-sm);
+}
+
+.solar-stat-label {
+  font-size: 0.8rem;
+  color: var(--grey-400);
+}
+
+.solar-stat-value {
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: var(--grey-800);
+}
+
+.solar-verdict {
+  margin-top: 1rem;
+  padding: 0.85rem 1rem;
+  border-radius: var(--radius-sm);
+  font-size: 0.95rem;
+  line-height: 1.5;
+  border-left: 3px solid var(--grey-200);
+  background: var(--grey-100, #f3f4f6);
+}
+
+.verdict-recommend {
+  background: var(--green-100);
+  border-left-color: var(--green-600);
+  color: var(--green-700);
+}
+
+.verdict-consider,
+.verdict-marginal {
+  background: #fef9c3;
+  border-left-color: #ca8a04;
+  color: #854d0e;
+}
+
+.verdict-uneconomic {
+  background: var(--coral-50);
+  border-left-color: var(--coral-500);
+  color: var(--grey-700);
+}
+
+.solar-pairing {
+  margin-top: 0.75rem;
+}
+
 .table-wrapper {
   overflow-x: auto;
 }

--- a/src/utils/analysis.js
+++ b/src/utils/analysis.js
@@ -24,11 +24,6 @@ function weekKey(d) {
   return start.toISOString().slice(0, 10);
 }
 
-/** Format a date as "DD Mon YYYY". */
-function formatDate(d) {
-  return d.toLocaleDateString("en-NZ", { day: "numeric", month: "short", year: "numeric" });
-}
-
 // ─── Average Daily Profile ──────────────────────────────────
 
 /**

--- a/src/utils/csvParser.js
+++ b/src/utils/csvParser.js
@@ -12,7 +12,11 @@
  *   3. If wide: find the date column, expand rows into 48 readings each
  *   4. If long: find the timestamp column and kWh column by header names + data patterns
  *   5. Validate values are reasonable for residential half-hourly data (0–5 kWh)
- *   6. Return normalised array of { timestamp: Date, kwh: number }
+ *   6. Return normalised array of { timestamp: Date, kwh: number, exportKwh: number }
+ *
+ * Solar export (two-way flows) is captured as `exportKwh` on each reading:
+ *   - A dedicated export/generation column (detected by header keywords), or
+ *   - Negative consumption values, which are treated as export.
  */
 
 import Papa from "papaparse";
@@ -24,6 +28,13 @@ const TIMESTAMP_PATTERNS = [
 const KWH_PATTERNS = [
   /kwh/i, /consumption/i, /usage/i, /energy/i, /demand/i, /reading/i,
   /value/i, /amount/i, /units/i,
+];
+// Header names that indicate a solar export / generation column.
+// Checked before the consumption patterns so an export column is never
+// mistaken for the import column.
+const EXPORT_PATTERNS = [
+  /export/i, /generation/i, /generated/i, /injection/i, /injected/i,
+  /feed[\s-]?in/i, /feed[\s-]?out/i, /supply\s*to\s*grid/i, /solar/i,
 ];
 
 // ─── Wide-format time-slot header patterns ──────────────────
@@ -158,11 +169,15 @@ function parseWideFormat(dataRows, timeColumns, dateColIndex, warnings) {
       const val = tc.colIndex < row.length ? row[tc.colIndex] : null;
       const kwh = parseFloat(val);
       if (isNaN(kwh) || val === null || val === "") continue;
-      if (kwh < 0) continue;
 
       const timestamp = new Date(baseDate);
       timestamp.setHours(tc.hour24, tc.minute, 0, 0);
-      data.push({ timestamp, kwh });
+      // Negative readings represent solar export back to the grid.
+      if (kwh < 0) {
+        data.push({ timestamp, kwh: 0, exportKwh: -kwh });
+      } else {
+        data.push({ timestamp, kwh, exportKwh: 0 });
+      }
     }
   }
 
@@ -382,7 +397,7 @@ function handleSummaryRows(data, dataRows, startCol, endCol, kwhCol, warnings) {
     }
 
     if (approxKwh !== null) {
-      cleaned.push({ timestamp: new Date(t), kwh: approxKwh });
+      cleaned.push({ timestamp: new Date(t), kwh: approxKwh, exportKwh: 0 });
       existingSlots.add(t);
       filledCount++;
 
@@ -428,6 +443,34 @@ function transpose(rows) {
     result.push(rows.map((r) => (col < r.length ? r[col] : "")));
   }
   return result;
+}
+
+/**
+ * Resolve import (kWh) and export (kWh) for a single reading.
+ * - A positive consumption value with a separate export column yields both.
+ * - A negative consumption value is treated as net export.
+ * Returns { kwh, exportKwh } or null if the consumption value is unparseable.
+ */
+function readImportExport(row, kwhCol, exportCol) {
+  const kwhRaw = kwhCol >= 0 && kwhCol < row.length ? row[kwhCol] : null;
+  const kwh = parseFloat(kwhRaw);
+  if (isNaN(kwh)) return null;
+
+  let importKwh = kwh;
+  let exportKwh = 0;
+
+  if (exportCol >= 0 && exportCol < row.length) {
+    const ex = parseFloat(row[exportCol]);
+    if (!isNaN(ex) && ex > 0) exportKwh = ex;
+  }
+
+  // Negative consumption represents net export back to the grid.
+  if (importKwh < 0) {
+    exportKwh += -importKwh;
+    importKwh = 0;
+  }
+
+  return { kwh: importKwh, exportKwh };
 }
 
 /**
@@ -520,6 +563,26 @@ export function parseCSV(fileContent) {
   // Determine number of columns
   const numCols = Math.max(...dataRows.slice(0, 20).map((r) => r.length));
 
+  // Identify a dedicated export column by header keyword first (e.g.
+  // "Export kWh", "Generation"). It is excluded from consumption-column
+  // scoring so an export column is never mistaken for the import column.
+  let exportCol = -1;
+  if (headers) {
+    for (let col = 0; col < numCols; col++) {
+      const headerName = headers[col] || "";
+      if (!EXPORT_PATTERNS.some((p) => p.test(headerName))) continue;
+      const values = dataRows.map((r) => (col < r.length ? r[col] : ""));
+      const numeric = values.slice(0, 50).filter((v) => {
+        const n = typeof v === "string" ? Number(v) : parseFloat(v);
+        return !isNaN(n);
+      }).length;
+      if (numeric > Math.min(50, values.length) * 0.5) {
+        exportCol = col;
+        break;
+      }
+    }
+  }
+
   // Score each column
   let bestTimestampCol = -1;
   let bestTimestampScore = 0;
@@ -527,6 +590,7 @@ export function parseCSV(fileContent) {
   let bestKwhScore = 0;
 
   for (let col = 0; col < numCols; col++) {
+    if (col === exportCol) continue;
     const values = dataRows.map((r) => (col < r.length ? r[col] : ""));
 
     // Check header name first
@@ -553,7 +617,7 @@ export function parseCSV(fileContent) {
     // Re-pick kwh from remaining columns
     bestKwhScore = 0;
     for (let col = 0; col < numCols; col++) {
-      if (col === bestTimestampCol) continue;
+      if (col === bestTimestampCol || col === exportCol) continue;
       const values = dataRows.map((r) => (col < r.length ? r[col] : ""));
       const headerName = headers ? headers[col] || "" : "";
       const kwhHeaderMatch = KWH_PATTERNS.some((p) => p.test(headerName));
@@ -569,7 +633,7 @@ export function parseCSV(fileContent) {
   let secondTimestampCol = -1;
   let secondTimestampScore = 0;
   for (let col = 0; col < numCols; col++) {
-    if (col === bestTimestampCol || col === bestKwhCol) continue;
+    if (col === bestTimestampCol || col === bestKwhCol || col === exportCol) continue;
     const values = dataRows.map((r) => (col < r.length ? r[col] : ""));
     const score = scoreTimestampColumn(values);
     if (score > secondTimestampScore) {
@@ -591,13 +655,12 @@ export function parseCSV(fileContent) {
 
   for (const row of dataRows) {
     const tsRaw = bestTimestampCol >= 0 && bestTimestampCol < row.length ? row[bestTimestampCol] : null;
-    const kwhRaw = bestKwhCol >= 0 && bestKwhCol < row.length ? row[bestKwhCol] : null;
 
     const ts = tryParseDate(String(tsRaw || ""));
-    const kwh = parseFloat(kwhRaw);
+    const reading = readImportExport(row, bestKwhCol, exportCol);
 
-    if (ts && !isNaN(kwh) && kwh >= 0) {
-      data.push({ timestamp: ts, kwh });
+    if (ts && reading) {
+      data.push({ timestamp: ts, ...reading });
     } else {
       parseErrors++;
     }
@@ -621,7 +684,7 @@ export function parseCSV(fileContent) {
     let bestIntervalCol = -1;
     let bestIntervalScore = 0;
     for (let col = 0; col < numCols; col++) {
-      if (col === bestTimestampCol || col === bestKwhCol) continue;
+      if (col === bestTimestampCol || col === bestKwhCol || col === exportCol) continue;
       const values = dataRows.map((r) => (col < r.length ? r[col] : ""));
       const score = scoreIntervalColumn(values);
       if (score > bestIntervalScore) {
@@ -634,17 +697,16 @@ export function parseCSV(fileContent) {
       const newData = [];
       for (const row of dataRows) {
         const tsRaw = bestTimestampCol >= 0 && bestTimestampCol < row.length ? row[bestTimestampCol] : null;
-        const kwhRaw = bestKwhCol >= 0 && bestKwhCol < row.length ? row[bestKwhCol] : null;
         const intervalRaw = bestIntervalCol < row.length ? row[bestIntervalCol] : null;
 
         const ts = tryParseDate(String(tsRaw || ""));
-        const kwh = parseFloat(kwhRaw);
+        const reading = readImportExport(row, bestKwhCol, exportCol);
         const interval = typeof intervalRaw === "number" ? intervalRaw : parseInt(intervalRaw);
 
-        if (ts && !isNaN(kwh) && kwh >= 0 && Number.isInteger(interval) && interval >= 1 && interval <= 48) {
+        if (ts && reading && Number.isInteger(interval) && interval >= 1 && interval <= 48) {
           const totalMinutes = (interval - 1) * 30;
           ts.setHours(Math.floor(totalMinutes / 60), totalMinutes % 60, 0, 0);
-          newData.push({ timestamp: ts, kwh });
+          newData.push({ timestamp: ts, ...reading });
         }
       }
       if (newData.length > 0) {

--- a/src/utils/pdfParser.js
+++ b/src/utils/pdfParser.js
@@ -48,6 +48,13 @@ const OFFPEAK_KEYWORDS = [
   "ev rate", "night",
 ];
 
+// Solar export / buy-back tariff (two-way energy flows)
+const EXPORT_KEYWORDS = [
+  "solar export", "export rate", "buy-back", "buy back", "buyback",
+  "feed-in", "feed in", "feedin", "distributed generation",
+  "solar buy", "exported", "export tariff", "generation credit",
+];
+
 // Lines containing these keywords are skipped (totals, headers, etc.)
 const SKIP_KEYWORDS = [
   "total", "subtotal", "sub-total", "gst", "tax",
@@ -213,7 +220,7 @@ function extractDailyRateFromLine(line) {
  */
 function scanLinesForRates(text) {
   const lines = text.split("\n");
-  const results = { dailyCharge: null, peakRate: null, offPeakRate: null };
+  const results = { dailyCharge: null, peakRate: null, offPeakRate: null, solarExportRate: null };
 
   for (const line of lines) {
     const lower = line.toLowerCase();
@@ -224,23 +231,32 @@ function scanLinesForRates(text) {
     // Skip total / GST / balance lines
     if (SKIP_KEYWORDS.some((kw) => lower.includes(kw))) continue;
 
+    // Solar export is checked first — these lines are specific and would
+    // otherwise be misclassified (e.g. "export rate" contains no other keyword).
+    const isExport = EXPORT_KEYWORDS.some((kw) => lower.includes(kw));
+
     // Classify the line
     const isDaily =
-      DAILY_KEYWORDS.some((kw) => lower.includes(kw)) ||
-      (lower.includes("daily") && !/kWh/i.test(line));
+      !isExport &&
+      (DAILY_KEYWORDS.some((kw) => lower.includes(kw)) ||
+        (lower.includes("daily") && !/kWh/i.test(line)));
 
     // Guard: "uncontrolled" contains "controlled" — don't let it trigger off-peak
     const hasUncontrolled = lower.includes("uncontrolled");
     const isOffPeak =
+      !isExport &&
       !hasUncontrolled &&
       OFFPEAK_KEYWORDS.some((kw) => lower.includes(kw));
 
     const isPeak =
-      !isOffPeak && !isDaily &&
+      !isExport && !isOffPeak && !isDaily &&
       PEAK_KEYWORDS.some((kw) => lower.includes(kw));
 
     // Extract the appropriate rate from this line
-    if (isDaily && results.dailyCharge === null) {
+    if (isExport && results.solarExportRate === null) {
+      const val = extractKwhRateFromLine(line);
+      if (val !== null) results.solarExportRate = val;
+    } else if (isDaily && results.dailyCharge === null) {
       const val = extractDailyRateFromLine(line);
       if (val !== null) results.dailyCharge = val;
     } else if (isOffPeak && results.offPeakRate === null) {
@@ -362,6 +378,12 @@ export async function extractTariffFromPDF(arrayBuffer) {
           "off-peak", "off peak", "night rate", "overnight",
           "controlled", "economy", "shoulder",
         ]),
+      solarExportRate:
+        lineRates.solarExportRate ??
+        findRateNearKeyword(text, [
+          "solar export", "export rate", "buy-back", "buy back", "buyback",
+          "feed-in", "feed in", "distributed generation", "export tariff",
+        ]),
     };
   } catch (err) {
     console.error("PDF parsing error:", err);
@@ -369,6 +391,7 @@ export async function extractTariffFromPDF(arrayBuffer) {
       dailyCharge: null,
       peakRate: null,
       offPeakRate: null,
+      solarExportRate: null,
     };
   }
 }

--- a/src/utils/solar.js
+++ b/src/utils/solar.js
@@ -11,6 +11,13 @@
  *
  * All readings are { timestamp: Date, kwh: number, exportKwh: number }.
  * Monetary maths is done in cents and converted to dollars at the boundary.
+ *
+ * Generation and cost constants (researched May 2026) are NZ market averages
+ * for modelling only — verify against quotes for a specific site. Sources:
+ *   - Peak sun hours / daily curve: GridFree (NIWA SolarView-derived)
+ *   - Yield per kW: Solar Scout (PVGIS), My Solar Quotes
+ *   - Solar capex: My Solar Quotes, EECA, Solar Republic
+ *   - Battery capex: Solar Scout, Electrify the Hutt, Tesla NZ
  */
 
 import { matchesTou } from "./analysis.js";
@@ -234,47 +241,53 @@ export function batteryROI(data, tariff, opts = {}) {
 // daylight window with a half-sine curve peaking at solar noon. Figures are NZ
 // averages; see SOLAR_DATA_LAST_UPDATED and the disclaimer surfaced in the UI.
 
-// Sourced figures — see PR description for citations.
+// Sourced figures — see PR description for citations (researched May 2026
+// from GridFree/NIWA SolarView, Solar Scout/PVGIS, My Solar Quotes, EECA).
 export const SOLAR_DATA_LAST_UPDATED = "May 2026";
 
 // Effective kWh generated per kW of installed panels per day, by month (Jan–Dec).
-// Annual sum ≈ NZ average yield per installed kW (~1300 kWh/kW/yr).
+// Derived from Auckland-representative peak-sun-hours (NIWA-based) scaled by a
+// ~0.87 performance ratio for system losses. Annual sum ≈ 1,350 kWh/kW/yr,
+// in line with NZ regional figures (Auckland 1,391 / Wellington 1,431 /
+// Christchurch 1,340 kWh/kW/yr). Intermediate months are interpolated.
 const NZ_KWH_PER_KW_DAY = [
-  5.0, // Jan (high summer)
-  4.5, // Feb
-  3.8, // Mar
-  3.0, // Apr
-  2.2, // May
-  1.8, // Jun (low winter)
-  2.0, // Jul
-  2.7, // Aug
-  3.5, // Sep
-  4.2, // Oct
-  4.7, // Nov
-  5.0, // Dec
+  4.87, // Jan (high summer)
+  4.61, // Feb
+  3.92, // Mar
+  3.13, // Apr
+  2.52, // May
+  2.26, // Jun (low winter)
+  2.44, // Jul
+  2.96, // Aug
+  3.65, // Sep
+  4.26, // Oct
+  4.70, // Nov
+  5.13, // Dec
 ];
 
 // Daylight generation window in local clock time [startHour, endHour] by month.
+// NZ: summer ~06:00–20:30, winter ~08:00–17:00 (interpolated between).
 const NZ_DAYLIGHT = [
-  [6.0, 20.8], // Jan
-  [6.7, 20.2], // Feb
-  [7.2, 19.3], // Mar
-  [7.0, 17.9], // Apr
-  [7.5, 17.2], // May
-  [7.8, 17.0], // Jun
-  [7.7, 17.2], // Jul
-  [7.1, 17.7], // Aug
-  [6.4, 18.3], // Sep
-  [6.4, 19.7], // Oct
-  [5.8, 20.3], // Nov
-  [5.8, 20.7], // Dec
+  [6.0, 20.5], // Jan
+  [6.4, 20.0], // Feb
+  [7.0, 19.2], // Mar
+  [7.3, 18.0], // Apr
+  [7.6, 17.3], // May
+  [8.0, 17.0], // Jun
+  [7.9, 17.1], // Jul
+  [7.4, 17.6], // Aug
+  [6.8, 18.4], // Sep
+  [6.3, 19.6], // Oct
+  [5.9, 20.2], // Nov
+  [5.8, 20.5], // Dec
 ];
 
-// Installed (turn-key) capex in NZD by system size. Researched NZ figures.
+// Installed (turn-key, incl. GST) capex in NZD by system size, 2025/26 NZ
+// market midpoints (~$1,700–2,300/kW; larger systems cost less per kW).
 export const SOLAR_SCENARIOS = [
   { sizeKw: 5, capex: 11000, label: "5 kW" },
-  { sizeKw: 8.5, capex: 16000, label: "8.5 kW" },
-  { sizeKw: 10, capex: 18500, label: "10 kW" },
+  { sizeKw: 8.5, capex: 16500, label: "8.5 kW" },
+  { sizeKw: 10, capex: 17500, label: "10 kW" },
 ];
 
 /**

--- a/src/utils/solar.js
+++ b/src/utils/solar.js
@@ -1,0 +1,455 @@
+/**
+ * Solar & Battery Economics — ROI models for two-way energy flows.
+ *
+ * Two analyses live here:
+ *   1. batteryROI()  — for households ALREADY exporting solar (issue #36):
+ *      models an 8 kWh battery that stores daytime export and discharges it
+ *      against after-sunset load, then computes a discounted payback period.
+ *   2. solarROI()    — for households WITHOUT solar (issue #37): models the
+ *      generation of 5 / 8.5 / 10 kW systems against the user's actual load
+ *      and computes a discounted payback period per scenario.
+ *
+ * All readings are { timestamp: Date, kwh: number, exportKwh: number }.
+ * Monetary maths is done in cents and converted to dollars at the boundary.
+ */
+
+import { matchesTou } from "./analysis.js";
+
+// ─── Shared financial assumptions ───────────────────────────
+// Real discount rate used for the time-value-of-money payback.
+export const DISCOUNT_RATE = 0.05;
+// Horizon (years) over which we look for a discounted payback before giving up.
+const PAYBACK_HORIZON_YEARS = 40;
+
+// ─── Battery assumptions (issue #36) ────────────────────────
+export const BATTERY_CAPACITY_KWH = 8;
+export const BATTERY_COST_NZD = 10000;
+
+// Minimum distinct calendar months of export data required to run the battery
+// analysis. Fewer than this is treated as "only one season" and skipped.
+const MIN_SOLAR_MONTHS = 5;
+// A day counts as a "solar day" once its total export exceeds this (kWh).
+const SOLAR_DAY_EXPORT_THRESHOLD = 0.1;
+
+/**
+ * Approximate sunset hour in NZ local clock time (includes daylight saving),
+ * indexed by month 0–11 (Jan–Dec). Used to define "after sunset" load.
+ * NZ latitude ~ -41°; midsummer sunset ~20:50 (NZDT), midwinter ~17:00 (NZST).
+ */
+const NZ_SUNSET_HOUR = [
+  20.8, // Jan
+  20.2, // Feb
+  19.3, // Mar
+  17.9, // Apr
+  17.2, // May
+  17.0, // Jun
+  17.2, // Jul
+  17.7, // Aug
+  18.3, // Sep
+  19.7, // Oct
+  20.3, // Nov
+  20.7, // Dec
+];
+
+// ─── Helpers ────────────────────────────────────────────────
+
+/** Local-date key "YYYY-MM-DD". */
+function dateKey(d) {
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+}
+
+/**
+ * Grid buy rate (cents/kWh) that applies to a reading, mirroring the
+ * current-tariff cost model: the base rate unless a TOU window matches.
+ */
+export function gridRateForReading(timestamp, tariff) {
+  const h = timestamp.getHours();
+  const dow = timestamp.getDay();
+  let rate = tariff.baseRate || 0;
+  for (const tou of tariff.touRates || []) {
+    if (matchesTou(h, dow, tou)) {
+      rate = tou.rate;
+      break;
+    }
+  }
+  return rate;
+}
+
+/** Is this reading after sunset for its month? */
+function isAfterSunset(timestamp) {
+  const hourFloat = timestamp.getHours() + timestamp.getMinutes() / 60;
+  return hourFloat >= NZ_SUNSET_HOUR[timestamp.getMonth()];
+}
+
+/** Span of a dataset in days (>= 1). */
+function spanDays(data) {
+  const first = data[0].timestamp.getTime();
+  const last = data[data.length - 1].timestamp.getTime();
+  return Math.max(1, (last - first) / 86400000);
+}
+
+/**
+ * Discounted payback period in years for a one-off capex paid up front and a
+ * level annual saving, using DISCOUNT_RATE. Returns a fractional year, or null
+ * if the discounted savings never recover the capex within the horizon.
+ */
+export function discountedPayback(capex, annualSaving, rate = DISCOUNT_RATE) {
+  if (annualSaving <= 0) return null;
+  let cumulative = 0;
+  for (let year = 1; year <= PAYBACK_HORIZON_YEARS; year++) {
+    const pv = annualSaving / Math.pow(1 + rate, year);
+    if (cumulative + pv >= capex) {
+      // Linear interpolation within the year for a smoother figure.
+      const remaining = capex - cumulative;
+      return year - 1 + remaining / pv;
+    }
+    cumulative += pv;
+  }
+  return null;
+}
+
+// ─── Battery ROI (issue #36) ────────────────────────────────
+
+/**
+ * Model an 8 kWh battery for a household that already exports solar.
+ *
+ * For each day the battery charges from that day's export (up to remaining
+ * capacity) and discharges against after-sunset load. Leftover charge carries
+ * over to the next day. The saving on each discharged kWh is the difference
+ * between the grid buy rate at the time of use and the export rate forgone.
+ *
+ * Returns:
+ *   { applicable: false, reason }                       — not enough solar data
+ *   { applicable: true, annualSaving, paybackYears,     — full result
+ *     recommendation, ... }
+ */
+export function batteryROI(data, tariff, opts = {}) {
+  const capacity = opts.capacityKwh ?? BATTERY_CAPACITY_KWH;
+  const cost = opts.costNzd ?? BATTERY_COST_NZD;
+  const exportRate = tariff.solarExportRate || 0;
+
+  if (!data || data.length === 0) {
+    return { applicable: false, reason: "No consumption data available." };
+  }
+
+  // Group readings by local date.
+  const days = new Map();
+  for (const d of data) {
+    const k = dateKey(d.timestamp);
+    if (!days.has(k)) days.set(k, []);
+    days.get(k).push(d);
+  }
+
+  // Identify solar days (days with visible export) and their months.
+  const solarMonths = new Set();
+  let totalAnnualExport = 0;
+  for (const [, readings] of days) {
+    const dayExport = readings.reduce((s, r) => s + (r.exportKwh || 0), 0);
+    if (dayExport > SOLAR_DAY_EXPORT_THRESHOLD) {
+      const m = readings[0].timestamp.getMonth();
+      solarMonths.add(m);
+    }
+  }
+
+  if (solarMonths.size === 0) {
+    return {
+      applicable: false,
+      reason: "No solar export was detected in your data, so a battery cannot time-shift exported energy.",
+    };
+  }
+
+  if (solarMonths.size < MIN_SOLAR_MONTHS) {
+    return {
+      applicable: false,
+      reason: `Your export data only covers ${solarMonths.size} month(s) — roughly one season. A full battery assessment needs export data spanning more of the year, so this analysis was skipped.`,
+      monthsCovered: solarMonths.size,
+    };
+  }
+
+  // Simulate chronologically, carrying battery charge across days.
+  const sortedKeys = [...days.keys()].sort();
+  let charge = 0;
+  let savingCents = 0;
+  let totalDischargeKwh = 0;
+
+  for (const k of sortedKeys) {
+    const readings = days.get(k).slice().sort((a, b) => a.timestamp - b.timestamp);
+
+    // Charge from today's export, limited by remaining capacity.
+    const dayExport = readings.reduce((s, r) => s + (r.exportKwh || 0), 0);
+    totalAnnualExport += dayExport;
+    charge = Math.min(capacity, charge + dayExport);
+
+    // Discharge against after-sunset load, in time order.
+    for (const r of readings) {
+      if (charge <= 0) break;
+      if (!isAfterSunset(r.timestamp)) continue;
+      const load = r.kwh || 0;
+      if (load <= 0) continue;
+      const discharge = Math.min(charge, load);
+      const gridRate = gridRateForReading(r.timestamp, tariff);
+      savingCents += discharge * Math.max(0, gridRate - exportRate);
+      charge -= discharge;
+      totalDischargeKwh += discharge;
+    }
+  }
+
+  // Annualise: scale the simulated saving to a single year. This averages
+  // multiple years down to one and extrapolates a partial (but multi-season)
+  // year up to a full year.
+  const span = spanDays(data);
+  const annualScale = 365 / span;
+  const annualSaving = (savingCents / 100) * annualScale;
+  const annualDischargeKwh = totalDischargeKwh * annualScale;
+
+  const paybackYears = discountedPayback(cost, annualSaving);
+
+  let recommendation;
+  if (paybackYears != null && paybackYears < 15) {
+    recommendation = "recommend";
+  } else if (paybackYears != null && paybackYears < 20) {
+    recommendation = "consider";
+  } else {
+    recommendation = "uneconomic";
+  }
+
+  return {
+    applicable: true,
+    capacityKwh: capacity,
+    cost,
+    exportRate,
+    monthsCovered: solarMonths.size,
+    annualExportKwh: totalAnnualExport * annualScale,
+    annualDischargeKwh,
+    annualSaving,
+    paybackYears,
+    recommendation,
+  };
+}
+
+// ─── Solar installation ROI (issue #37) ─────────────────────
+//
+// Generation is modelled from an effective-sun-hours figure (kWh generated per
+// kW of panels per day, already net of typical system losses) shaped across the
+// daylight window with a half-sine curve peaking at solar noon. Figures are NZ
+// averages; see SOLAR_DATA_LAST_UPDATED and the disclaimer surfaced in the UI.
+
+// Sourced figures — see PR description for citations.
+export const SOLAR_DATA_LAST_UPDATED = "May 2026";
+
+// Effective kWh generated per kW of installed panels per day, by month (Jan–Dec).
+// Annual sum ≈ NZ average yield per installed kW (~1300 kWh/kW/yr).
+const NZ_KWH_PER_KW_DAY = [
+  5.0, // Jan (high summer)
+  4.5, // Feb
+  3.8, // Mar
+  3.0, // Apr
+  2.2, // May
+  1.8, // Jun (low winter)
+  2.0, // Jul
+  2.7, // Aug
+  3.5, // Sep
+  4.2, // Oct
+  4.7, // Nov
+  5.0, // Dec
+];
+
+// Daylight generation window in local clock time [startHour, endHour] by month.
+const NZ_DAYLIGHT = [
+  [6.0, 20.8], // Jan
+  [6.7, 20.2], // Feb
+  [7.2, 19.3], // Mar
+  [7.0, 17.9], // Apr
+  [7.5, 17.2], // May
+  [7.8, 17.0], // Jun
+  [7.7, 17.2], // Jul
+  [7.1, 17.7], // Aug
+  [6.4, 18.3], // Sep
+  [6.4, 19.7], // Oct
+  [5.8, 20.3], // Nov
+  [5.8, 20.7], // Dec
+];
+
+// Installed (turn-key) capex in NZD by system size. Researched NZ figures.
+export const SOLAR_SCENARIOS = [
+  { sizeKw: 5, capex: 11000, label: "5 kW" },
+  { sizeKw: 8.5, capex: 16000, label: "8.5 kW" },
+  { sizeKw: 10, capex: 18500, label: "10 kW" },
+];
+
+/**
+ * Per-month array of 48 half-hour generation weights that sum to 1, shaping the
+ * daily generation across the daylight window with a half-sine curve.
+ */
+const MONTH_WEIGHTS = NZ_DAYLIGHT.map(([start, end]) => {
+  const raw = [];
+  let sum = 0;
+  for (let slot = 0; slot < 48; slot++) {
+    const h = slot / 2;
+    let v = 0;
+    if (h >= start && h < end) {
+      v = Math.sin((Math.PI * (h - start)) / (end - start));
+    }
+    raw.push(v);
+    sum += v;
+  }
+  return sum > 0 ? raw.map((v) => v / sum) : raw;
+});
+
+/** Modelled generation (kWh) for a reading and a system size. */
+function generationForReading(timestamp, sizeKw) {
+  const m = timestamp.getMonth();
+  const slot = timestamp.getHours() * 2 + (timestamp.getMinutes() >= 30 ? 1 : 0);
+  const dailyPerKw = NZ_KWH_PER_KW_DAY[m];
+  return sizeKw * dailyPerKw * MONTH_WEIGHTS[m][slot];
+}
+
+/** Annuity factor: present value of $1/year for `years` years at `rate`. */
+function annuityFactor(years, rate = DISCOUNT_RATE) {
+  let f = 0;
+  for (let t = 1; t <= years; t++) f += 1 / Math.pow(1 + rate, t);
+  return f;
+}
+
+/**
+ * Evaluate a single solar scenario against the user's load.
+ * Returns per-scenario economics plus the modelled per-reading surplus export
+ * (used for battery pairing).
+ */
+function evaluateScenario(data, tariff, scenario, annualScale) {
+  const exportRate = tariff.solarExportRate || 0;
+  let selfCents = 0;
+  let exportCents = 0;
+  let genKwh = 0;
+  let surplusKwh = 0;
+  // Synthetic post-solar profile for battery pairing.
+  const synthetic = [];
+
+  for (const r of data) {
+    const load = r.kwh || 0;
+    const gen = generationForReading(r.timestamp, scenario.sizeKw);
+    genKwh += gen;
+
+    const selfConsumed = Math.min(gen, load);
+    const exported = Math.max(0, gen - load);
+    const residualLoad = Math.max(0, load - gen);
+    surplusKwh += exported;
+
+    const gridRate = gridRateForReading(r.timestamp, tariff);
+    selfCents += selfConsumed * gridRate;
+    exportCents += exported * exportRate;
+
+    synthetic.push({ timestamp: r.timestamp, kwh: residualLoad, exportKwh: exported });
+  }
+
+  const annualSaving = ((selfCents + exportCents) / 100) * annualScale;
+  const paybackYears = discountedPayback(scenario.capex, annualSaving);
+
+  return {
+    ...scenario,
+    annualSaving,
+    annualGenerationKwh: genKwh * annualScale,
+    annualSurplusKwh: surplusKwh * annualScale,
+    paybackYears,
+    synthetic,
+  };
+}
+
+/**
+ * Model 5 / 8.5 / 10 kW solar installations against the user's actual load,
+ * pick the best scenario, and (per issue #37) test whether adding a battery
+ * improves the economics further.
+ */
+export function solarROI(data, tariff) {
+  if (!data || data.length === 0) {
+    return { applicable: false, reason: "No consumption data available." };
+  }
+
+  const span = spanDays(data);
+  const annualScale = 365 / span;
+
+  // Load-weighted average grid rate, used for the load-shifting estimate.
+  let loadKwh = 0;
+  let loadRateCents = 0;
+  for (const r of data) {
+    const load = r.kwh || 0;
+    loadKwh += load;
+    loadRateCents += load * gridRateForReading(r.timestamp, tariff);
+  }
+  const annualLoadKwh = loadKwh * annualScale;
+  const avgGridRate = loadKwh > 0 ? loadRateCents / loadKwh : tariff.baseRate || 0;
+  const exportRate = tariff.solarExportRate || 0;
+
+  const scenarios = SOLAR_SCENARIOS.map((s) =>
+    evaluateScenario(data, tariff, s, annualScale)
+  );
+
+  // Best scenario: shortest discounted payback; fall back to highest saving.
+  const withPayback = scenarios.filter((s) => s.paybackYears != null);
+  const best = withPayback.length > 0
+    ? withPayback.reduce((a, b) => (b.paybackYears < a.paybackYears ? b : a))
+    : scenarios.reduce((a, b) => (b.annualSaving > a.annualSaving ? b : a));
+
+  // Recommendation tiers from the best scenario's payback.
+  let recommendation;
+  let loadShift = null;
+  const payback = best.paybackYears;
+
+  if (payback != null && payback < 10) {
+    recommendation = "recommend";
+  } else if (payback != null && payback < 15) {
+    recommendation = "marginal";
+    // Extra annual saving needed to reach a 10-year discounted payback.
+    const requiredAnnual = best.capex / annuityFactor(10);
+    const deltaAnnual = requiredAnnual - best.annualSaving;
+    const rateGap = Math.max(0, avgGridRate - exportRate); // cents/kWh gained per shifted kWh
+    if (deltaAnnual > 0 && rateGap > 0) {
+      const shiftKwh = (deltaAnnual * 100) / rateGap;
+      // Cannot self-consume more than the surplus currently exported.
+      const achievable = shiftKwh <= best.annualSurplusKwh;
+      const pct = annualLoadKwh > 0 ? (shiftKwh / annualLoadKwh) * 100 : null;
+      loadShift = {
+        kwhPerYear: shiftKwh,
+        percentOfLoad: pct,
+        achievable,
+      };
+    }
+  } else {
+    recommendation = "uneconomic";
+  }
+
+  // Battery pairing: run the battery model on the best scenario's post-solar
+  // export profile to see if it improves the economics further.
+  let battery = batteryROI(best.synthetic, tariff);
+  let combined = null;
+  if (battery.applicable && battery.annualSaving > 0) {
+    const combinedCapex = best.capex + battery.cost;
+    const combinedAnnual = best.annualSaving + battery.annualSaving;
+    combined = {
+      capex: combinedCapex,
+      annualSaving: combinedAnnual,
+      paybackYears: discountedPayback(combinedCapex, combinedAnnual),
+    };
+  }
+  // Strip the bulky synthetic arrays before returning.
+  const cleanScenarios = scenarios.map((s) => {
+    const copy = { ...s };
+    delete copy.synthetic;
+    return copy;
+  });
+  const { synthetic: _omit, ...cleanBest } = best;
+
+  return {
+    applicable: true,
+    dataUpdated: SOLAR_DATA_LAST_UPDATED,
+    annualLoadKwh,
+    avgGridRate,
+    exportRate,
+    scenarios: cleanScenarios,
+    best: cleanBest,
+    recommendation,
+    loadShift,
+    battery: battery.applicable ? battery : null,
+    combined,
+  };
+}

--- a/test/csvParser.test.js
+++ b/test/csvParser.test.js
@@ -473,7 +473,7 @@ describe("parseCSV — edge cases", () => {
     expect(result.data).toHaveLength(0);
   });
 
-  it("ignores rows with negative kWh values", () => {
+  it("treats negative kWh values as solar export", () => {
     const rows = [];
     rows.push("timestamp,kwh");
     // Need at least 10 rows for the parser to proceed
@@ -482,8 +482,29 @@ describe("parseCSV — edge cases", () => {
       rows.push(`2025-03-03 ${h}:00:00,${i === 5 ? -0.5 : 0.3}`);
     }
     const result = parseCSV(rows.join("\n"));
-    // The negative row should be excluded
+    // Import is never negative; the negative reading becomes export instead.
     expect(result.data.every((d) => d.kwh >= 0)).toBe(true);
-    expect(result.data.length).toBe(11); // 12 - 1 negative
+    expect(result.data.length).toBe(12); // negative row is kept as export
+    const exportRow = result.data.find((d) => d.exportKwh > 0);
+    expect(exportRow).toBeDefined();
+    expect(exportRow.kwh).toBe(0);
+    expect(exportRow.exportKwh).toBeCloseTo(0.5, 5);
+  });
+
+  it("reads a dedicated export column alongside consumption", () => {
+    const rows = [];
+    rows.push("timestamp,kwh,export_kwh");
+    for (let i = 0; i < 12; i++) {
+      const h = String(i).padStart(2, "0");
+      // Midday rows export, others only import
+      const exp = i >= 10 && i <= 14 ? 0.8 : 0;
+      rows.push(`2025-03-03 ${h}:00:00,0.3,${exp}`);
+    }
+    const result = parseCSV(rows.join("\n"));
+    expect(result.data.length).toBe(12);
+    const exporting = result.data.filter((d) => d.exportKwh > 0);
+    expect(exporting.length).toBe(2); // hours 10, 11 (within loop range)
+    expect(exporting[0].kwh).toBeCloseTo(0.3, 5);
+    expect(exporting[0].exportKwh).toBeCloseTo(0.8, 5);
   });
 });

--- a/test/solar.test.js
+++ b/test/solar.test.js
@@ -1,0 +1,219 @@
+import { describe, it, expect } from "vitest";
+import {
+  batteryROI,
+  solarROI,
+  discountedPayback,
+  gridRateForReading,
+  SOLAR_SCENARIOS,
+  DISCOUNT_RATE,
+} from "../src/utils/solar.js";
+
+// ─── Data generators ─────────────────────────────────────────
+
+/**
+ * Build half-hourly data for `days` days from a start date.
+ * profileFn(hourFloat, date) → { kwh, exportKwh }.
+ */
+function buildData(startDate, days, profileFn) {
+  const data = [];
+  const start = new Date(startDate);
+  for (let d = 0; d < days; d++) {
+    for (let slot = 0; slot < 48; slot++) {
+      const ts = new Date(start.getTime() + d * 86400000 + slot * 1800000);
+      const hourFloat = ts.getHours() + ts.getMinutes() / 60;
+      const { kwh = 0, exportKwh = 0 } = profileFn(hourFloat, ts) || {};
+      data.push({ timestamp: ts, kwh, exportKwh });
+    }
+  }
+  return data;
+}
+
+// A simple year-long profile: midday export, evening load, low daytime import.
+function solarHomeProfile(hourFloat) {
+  // Midday 10:00–14:00 exports
+  if (hourFloat >= 10 && hourFloat < 14) return { kwh: 0, exportKwh: 1.0 };
+  // Evening 20:00–23:00 has load (after sunset most of the year)
+  if (hourFloat >= 20 && hourFloat < 23) return { kwh: 0.8, exportKwh: 0 };
+  // Light background import
+  return { kwh: 0.1, exportKwh: 0 };
+}
+
+const FLAT_TARIFF = { baseRate: 30, touRates: [], solarExportRate: 8 };
+
+// ─── discountedPayback ───────────────────────────────────────
+
+describe("discountedPayback", () => {
+  it("returns null when there is no saving", () => {
+    expect(discountedPayback(10000, 0)).toBeNull();
+    expect(discountedPayback(10000, -50)).toBeNull();
+  });
+
+  it("never recovers a large capex with a tiny saving", () => {
+    // $50/yr discounted will never reach $10,000.
+    expect(discountedPayback(10000, 50)).toBeNull();
+  });
+
+  it("payback is longer than the simple (undiscounted) payback", () => {
+    const capex = 10000;
+    const annual = 1500;
+    const simple = capex / annual; // ~6.67 years
+    const discounted = discountedPayback(capex, annual);
+    expect(discounted).not.toBeNull();
+    expect(discounted).toBeGreaterThan(simple);
+  });
+
+  it("matches a hand-computed cumulative PV", () => {
+    // capex small enough to be repaid partway through year 2.
+    const r = DISCOUNT_RATE;
+    const annual = 1000;
+    const pv1 = annual / (1 + r); // ~952.38
+    const capex = pv1 + 100; // needs a bit into year 2
+    const payback = discountedPayback(capex, annual, r);
+    expect(payback).toBeGreaterThan(1);
+    expect(payback).toBeLessThan(2);
+  });
+});
+
+// ─── gridRateForReading ──────────────────────────────────────
+
+describe("gridRateForReading", () => {
+  it("returns the base rate when no TOU matches", () => {
+    const ts = new Date("2025-06-15T12:00:00");
+    expect(gridRateForReading(ts, FLAT_TARIFF)).toBe(30);
+  });
+
+  it("returns a matching TOU rate", () => {
+    const tariff = {
+      baseRate: 30,
+      touRates: [{ rate: 15, startHour: 21, endHour: 7, days: [0, 1, 2, 3, 4, 5, 6] }],
+    };
+    const night = new Date("2025-06-15T22:00:00");
+    const day = new Date("2025-06-15T12:00:00");
+    expect(gridRateForReading(night, tariff)).toBe(15);
+    expect(gridRateForReading(day, tariff)).toBe(30);
+  });
+});
+
+// ─── batteryROI — applicability ──────────────────────────────
+
+describe("batteryROI applicability", () => {
+  it("skips when there is no export at all", () => {
+    const data = buildData("2025-01-01T00:00:00", 200, () => ({ kwh: 0.3, exportKwh: 0 }));
+    const result = batteryROI(data, FLAT_TARIFF);
+    expect(result.applicable).toBe(false);
+    expect(result.reason).toMatch(/no solar export/i);
+  });
+
+  it("skips when export only covers one season (< 5 months)", () => {
+    // Export only in Jan–Mar (3 months).
+    const data = buildData("2025-01-01T00:00:00", 365, (h, ts) => {
+      const exporting = ts.getMonth() <= 2 && h >= 10 && h < 14;
+      return exporting ? { kwh: 0, exportKwh: 1.0 } : { kwh: 0.3, exportKwh: 0 };
+    });
+    const result = batteryROI(data, FLAT_TARIFF);
+    expect(result.applicable).toBe(false);
+    expect(result.reason).toMatch(/one season/i);
+    expect(result.monthsCovered).toBe(3);
+  });
+
+  it("runs when export spans most of the year", () => {
+    const data = buildData("2025-01-01T00:00:00", 365, solarHomeProfile);
+    const result = batteryROI(data, FLAT_TARIFF);
+    expect(result.applicable).toBe(true);
+    expect(result.monthsCovered).toBeGreaterThanOrEqual(5);
+    expect(result.annualSaving).toBeGreaterThan(0);
+    expect(result.annualDischargeKwh).toBeGreaterThan(0);
+    expect(["recommend", "consider", "uneconomic"]).toContain(result.recommendation);
+  });
+});
+
+// ─── batteryROI — savings logic ──────────────────────────────
+
+describe("batteryROI savings", () => {
+  it("saving per kWh equals grid rate minus export rate", () => {
+    const data = buildData("2025-01-01T00:00:00", 365, solarHomeProfile);
+    const result = batteryROI(data, FLAT_TARIFF);
+    // Each discharged kWh should save (30 - 8) = 22c.
+    const impliedSavingPerKwh = (result.annualSaving * 100) / result.annualDischargeKwh;
+    expect(impliedSavingPerKwh).toBeCloseTo(22, 1);
+  });
+
+  it("higher export rate reduces battery savings", () => {
+    const data = buildData("2025-01-01T00:00:00", 365, solarHomeProfile);
+    const low = batteryROI(data, { ...FLAT_TARIFF, solarExportRate: 8 });
+    const high = batteryROI(data, { ...FLAT_TARIFF, solarExportRate: 25 });
+    expect(high.annualSaving).toBeLessThan(low.annualSaving);
+  });
+
+  it("a strong economic case yields a recommend/consider verdict", () => {
+    // Large evening load + big daily export + cheap export buy-back, expensive grid.
+    const data = buildData("2025-01-01T00:00:00", 365, (h) => {
+      if (h >= 9 && h < 15) return { kwh: 0, exportKwh: 3.0 };   // lots of export
+      if (h >= 19 && h < 23) return { kwh: 2.0, exportKwh: 0 };  // heavy evening load
+      return { kwh: 0.2, exportKwh: 0 };
+    });
+    const tariff = { baseRate: 45, touRates: [], solarExportRate: 5 };
+    const result = batteryROI(data, tariff);
+    expect(result.applicable).toBe(true);
+    expect(result.annualSaving).toBeGreaterThan(0);
+    expect(result.paybackYears).not.toBeNull();
+  });
+});
+
+// ─── solarROI ────────────────────────────────────────────────
+
+describe("solarROI", () => {
+  // A year of steady load, no existing solar.
+  const yearLoad = buildData("2025-01-01T00:00:00", 365, () => ({ kwh: 0.4, exportKwh: 0 }));
+  const tariff = { baseRate: 32, touRates: [], solarExportRate: 10 };
+
+  it("returns one result per configured scenario", () => {
+    const result = solarROI(yearLoad, tariff);
+    expect(result.applicable).toBe(true);
+    expect(result.scenarios).toHaveLength(SOLAR_SCENARIOS.length);
+  });
+
+  it("models a realistic annual yield per kW (~1300 kWh/kW/yr)", () => {
+    const result = solarROI(yearLoad, tariff);
+    const fiveKw = result.scenarios.find((s) => s.sizeKw === 5);
+    const yieldPerKw = fiveKw.annualGenerationKwh / 5;
+    expect(yieldPerKw).toBeGreaterThan(1000);
+    expect(yieldPerKw).toBeLessThan(1600);
+  });
+
+  it("larger systems generate more energy", () => {
+    const result = solarROI(yearLoad, tariff);
+    const gens = result.scenarios.map((s) => s.annualGenerationKwh);
+    expect(gens[1]).toBeGreaterThan(gens[0]);
+    expect(gens[2]).toBeGreaterThan(gens[1]);
+  });
+
+  it("picks a best scenario and a valid recommendation", () => {
+    const result = solarROI(yearLoad, tariff);
+    expect(result.best).toBeDefined();
+    expect(SOLAR_SCENARIOS.map((s) => s.sizeKw)).toContain(result.best.sizeKw);
+    expect(["recommend", "marginal", "uneconomic"]).toContain(result.recommendation);
+  });
+
+  it("self-consumption is worth more than export, so daytime load lifts savings", () => {
+    // Heavy daytime load self-consumes generation (saves full grid rate).
+    const daytimeHeavy = buildData("2025-01-01T00:00:00", 365, (h) =>
+      h >= 9 && h < 16 ? { kwh: 2.0, exportKwh: 0 } : { kwh: 0.2, exportKwh: 0 }
+    );
+    const nightHeavy = buildData("2025-01-01T00:00:00", 365, (h) =>
+      h >= 19 || h < 6 ? { kwh: 2.0, exportKwh: 0 } : { kwh: 0.2, exportKwh: 0 }
+    );
+    const dayResult = solarROI(daytimeHeavy, tariff);
+    const nightResult = solarROI(nightHeavy, tariff);
+    // Same total load, but daytime users self-consume more → bigger savings.
+    expect(dayResult.best.annualSaving).toBeGreaterThan(nightResult.best.annualSaving);
+  });
+
+  it("attempts battery pairing on the post-solar export profile", () => {
+    const result = solarROI(yearLoad, tariff);
+    // With a full year of modelled solar there is surplus export across seasons,
+    // so the battery model should at least run (applicable) on the synthetic data.
+    expect(result.battery).not.toBeNull();
+    expect(result.battery.applicable).toBe(true);
+  });
+});


### PR DESCRIPTION
Closes #36 and #37.

## Summary

Adds support for two-way energy flows and two ROI models for solar/battery economics.

### Issue #36 — Solar export & battery ROI (for households already exporting)
- **CSV parser** captures export as `exportKwh` on each reading — both a dedicated export/generation column (header keywords like `export`, `generation`, `feed-in`) and negative consumption values.
- **PDF parser** detects a solar export / buy-back / feed-in / distributed-generation rate from the bill.
- **Tariff review** gains a "+ Add solar export rate" field, autofilled from the parsed PDF.
- **`batteryROI()`** (`src/utils/solar.js`) simulates an 8 kWh battery day-by-day: charges from each day's export (capped at remaining capacity), discharges against after-sunset load, and carries leftover charge to the next day. Per-kWh saving = grid buy rate at time of use − export rate forgone. It skips when export data covers only one season (< 5 months), annualises otherwise (averaging multiple years / extrapolating partial years), and reports a 5% discounted payback with a **recommend (<15y) / consider (<20y) / uneconomic** verdict. Uneconomic cases note the resilience-measure angle.

### Issue #37 — Solar installation ROI (for households without solar)
- **`solarROI()`** models 5 / 8.5 / 10 kW systems from average NZ sun-hours (half-sine generation curve across the daylight window), compares modelled generation to the user's actual half-hourly load (self-consumption saves the grid rate; surplus earns the export rate), and ranks scenarios by discounted payback.
- **<10y** → recommends the best-value scenario. **10–15y** → reports the payback and the approximate % of load that, if shifted into daylight hours, would bring it under 10 years. **>15y** → not currently economic.
- Per the issue, it then runs the **battery model on the modelled post-solar export profile** to test whether battery pairing improves the combined economics.

### Dashboard
Renders a **Battery Storage Assessment** for households already exporting, or a **"Should You Install Solar?"** assessment (scenario table + verdict + battery-pairing note) for everyone else.

## Assumptions (researched May 2026)
Financial and physical constants live at the top of `src/utils/solar.js` with a `SOLAR_DATA_LAST_UPDATED` marker and a UI disclaimer (same convention as `tariffs.js`). These are NZ market averages for modelling only — verify against quotes for a specific site.

- **5% real discount rate** for discounted payback.
- **Generation:** Auckland-representative peak-sun-hours (NIWA SolarView-derived) scaled by a ~0.87 performance ratio → **~1,350 kWh/kW/yr**, matching regional figures (Auckland 1,391 / Wellington 1,431 / Christchurch 1,340). Monthly profile + summer ~06:00–20:30 / winter ~08:00–17:00 daylight windows.
- **Installed solar capex** (turn-key, incl. GST, 2025/26 midpoints, ~$1,700–2,300/kW): 5 kW **$11,000** · 8.5 kW **$16,500** · 10 kW **$17,500**.
- **8 kWh battery $10,000** (per issue #36) — confirmed realistic for a mid-market value brand.

Sources: GridFree / NIWA SolarView (sun hours); Solar Scout/PVGIS, My Solar Quotes (yield); My Solar Quotes, EECA, Solar Republic (solar capex); Solar Scout, Electrify the Hutt, Tesla NZ (battery). Some figures (intermediate months, the 8.5 kW price) are interpolated between cited anchors and flagged as modelled.

## Test plan
- [x] `npm test` — 100 tests pass (added `test/solar.test.js`: discounted payback, grid-rate lookup, battery applicability/savings, solar scenario yield/ranking/pairing; updated `test/csvParser.test.js` for export parsing).
- [x] `npm run lint` — clean.
- [x] `npm run build` — succeeds.
- [x] Dev server boots and serves (HTTP 200).
- [x] Manual browser click-through not performed (no browser in the remote env) — worth a visual check of both dashboard sections with real export and non-export CSVs.

https://claude.ai/code/session_01Qyo3Fo2ZQZCHyPZwZdKmsj