### PR TITLE
Add dev-only solar calculations breakdown card

### DIFF
--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -8,7 +8,7 @@ import {
   dailyProfile, seasonalProfiles, weeklyTrend,
   generateInsights, currentAnnualCost, rankPlans,
 } from "../utils/analysis.js";
-import { batteryROI, solarROI, DISCOUNT_RATE } from "../utils/solar.js";
+import { batteryROI, solarROI, DISCOUNT_RATE, DEV_MODE } from "../utils/solar.js";
 import { tariffsLastUpdated } from "../tariffs.js";
 import StepIndicator from "./StepIndicator.jsx";
 
@@ -420,6 +420,76 @@ export default function Dashboard({ data, currentTariff, onStepClick }) {
                   : " — but it does not improve on solar alone, so the battery is best treated as a resilience add-on."}
               </p>
             )}
+          </section>
+        )}
+
+        {/* ── DEV ONLY: Solar internal calculations (set DEV_MODE=false to hide) ── */}
+        {DEV_MODE && solar && solar.applicable && solar.debug && (
+          <section className="solar-section card-coral">
+            <h3>🛠️ Solar Maths Breakdown (dev only)</h3>
+            <p className="data-note" style={{ fontSize: "0.85rem", color: "#666", marginBottom: "0.5rem" }}>
+              Internal calculations for the best scenario ({solar.debug.label}),
+              shown so the figures can be verified. This card is hidden in
+              production (DEV_MODE = false).
+            </p>
+
+            <div className="solar-stats">
+              <div className="solar-stat">
+                <span className="solar-stat-label">Saving from self-consumption</span>
+                <span className="solar-stat-value">${Math.round(solar.debug.selfConsumptionSaving).toLocaleString()}/yr</span>
+              </div>
+              <div className="solar-stat">
+                <span className="solar-stat-label">Earnings from export</span>
+                <span className="solar-stat-value">${Math.round(solar.debug.exportEarning).toLocaleString()}/yr</span>
+              </div>
+              <div className="solar-stat">
+                <span className="solar-stat-label">Total annual saving</span>
+                <span className="solar-stat-value">${Math.round(solar.debug.selfConsumptionSaving + solar.debug.exportEarning).toLocaleString()}/yr</span>
+              </div>
+              <div className="solar-stat">
+                <span className="solar-stat-label">Modelled annual generation</span>
+                <span className="solar-stat-value">{Math.round(solar.debug.annualGenerationKwh).toLocaleString()} kWh</span>
+              </div>
+            </div>
+
+            {solar.debug.inflation && (
+              <>
+                <h4 style={{ margin: "1rem 0 0.25rem" }}>Value lost to discounting / inflation</h4>
+                <p className="chart-desc" style={{ marginTop: 0 }}>
+                  Over the {solar.debug.inflation.paybackYears.toFixed(1)}-year payback you save
+                  ${Math.round(solar.debug.inflation.nominalCumulative).toLocaleString()} in nominal dollars,
+                  but at the {Math.round(DISCOUNT_RATE * 100)}% real discount rate those savings are only
+                  worth ${Math.round(solar.debug.inflation.presentValue).toLocaleString()} today (≈ the
+                  install cost). The difference,
+                  ${Math.round(solar.debug.inflation.lostToDiscounting).toLocaleString()}, is eroded by
+                  the time-value of money.
+                </p>
+              </>
+            )}
+
+            <h4 style={{ margin: "1rem 0 0.25rem" }}>Generation by month</h4>
+            <div className="table-wrapper">
+              <table className="plans-table">
+                <thead>
+                  <tr>
+                    <th>Month</th>
+                    <th>kWh per kW/day</th>
+                    <th>Avg generation per day</th>
+                    <th>Total for the month</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {solar.debug.months.map((m) => (
+                    <tr key={m.month}>
+                      <td className="retailer">{m.month}</td>
+                      <td>{m.kwhPerKwDay.toFixed(2)}</td>
+                      <td>{m.avgDailyKwh.toFixed(1)} kWh</td>
+                      <td>{Math.round(m.monthlyKwh).toLocaleString()} kWh</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
           </section>
         )}
 

--- a/src/utils/solar.js
+++ b/src/utils/solar.js
@@ -22,6 +22,11 @@
 
 import { matchesTou } from "./analysis.js";
 
+// Dev-only flag. While true the UI surfaces an internal-calculations card so
+// the underlying maths can be verified against real data. Set to false before
+// shipping to production to hide that card.
+export const DEV_MODE = true;
+
 // ─── Shared financial assumptions ───────────────────────────
 // Real discount rate used for the time-value-of-money payback.
 export const DISCOUNT_RATE = 0.05;
@@ -317,6 +322,64 @@ function generationForReading(timestamp, sizeKw) {
   return sizeKw * dailyPerKw * MONTH_WEIGHTS[m][slot];
 }
 
+// Days per month (Jan–Dec) for turning a daily generation figure into a
+// monthly total. Feb uses 28 — close enough for modelling.
+const DAYS_IN_MONTH = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+
+const MONTH_NAMES = [
+  "Jan", "Feb", "Mar", "Apr", "May", "Jun",
+  "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
+];
+
+/**
+ * Build the dev-only internal-calculations breakdown for the chosen scenario,
+ * so the maths can be sanity-checked against the source constants:
+ *   - self-consumption saving vs export earning (annualised, from `best`)
+ *   - modelled generation per month and per average day of that month, taken
+ *     straight from NZ_KWH_PER_KW_DAY × system size (independent of data span)
+ *   - value eroded by discounting/inflation: nominal cumulative savings over
+ *     the payback period vs their present value (which equals the capex).
+ */
+function buildSolarDebug(best) {
+  const sizeKw = best.sizeKw;
+  const months = MONTH_NAMES.map((name, m) => {
+    const avgDailyKwh = sizeKw * NZ_KWH_PER_KW_DAY[m];
+    return {
+      month: name,
+      kwhPerKwDay: NZ_KWH_PER_KW_DAY[m],
+      avgDailyKwh,
+      monthlyKwh: avgDailyKwh * DAYS_IN_MONTH[m],
+    };
+  });
+  const annualGenerationKwh = months.reduce((s, x) => s + x.monthlyKwh, 0);
+
+  // Discounting/inflation erosion over the payback period. By the definition of
+  // discounted payback the present value of savings at payback ≈ the capex, so
+  // the gap to the nominal sum is what time-value-of-money (inflation) erodes.
+  let inflation = null;
+  if (best.paybackYears != null) {
+    const nominalCumulative = best.annualSaving * best.paybackYears;
+    const presentValue = best.capex;
+    inflation = {
+      paybackYears: best.paybackYears,
+      annualSaving: best.annualSaving,
+      nominalCumulative,
+      presentValue,
+      lostToDiscounting: nominalCumulative - presentValue,
+    };
+  }
+
+  return {
+    sizeKw,
+    label: best.label,
+    selfConsumptionSaving: best.selfConsumptionSaving,
+    exportEarning: best.exportEarning,
+    months,
+    annualGenerationKwh,
+    inflation,
+  };
+}
+
 /** Annuity factor: present value of $1/year for `years` years at `rate`. */
 function annuityFactor(years, rate = DISCOUNT_RATE) {
   let f = 0;
@@ -355,12 +418,16 @@ function evaluateScenario(data, tariff, scenario, annualScale) {
     synthetic.push({ timestamp: r.timestamp, kwh: residualLoad, exportKwh: exported });
   }
 
-  const annualSaving = ((selfCents + exportCents) / 100) * annualScale;
+  const selfConsumptionSaving = (selfCents / 100) * annualScale;
+  const exportEarning = (exportCents / 100) * annualScale;
+  const annualSaving = selfConsumptionSaving + exportEarning;
   const paybackYears = discountedPayback(scenario.capex, annualSaving);
 
   return {
     ...scenario,
     annualSaving,
+    selfConsumptionSaving,
+    exportEarning,
     annualGenerationKwh: genKwh * annualScale,
     annualSurplusKwh: surplusKwh * annualScale,
     paybackYears,
@@ -464,5 +531,6 @@ export function solarROI(data, tariff) {
     loadShift,
     battery: battery.applicable ? battery : null,
     combined,
+    debug: DEV_MODE ? buildSolarDebug(best) : null,
   };
 }


### PR DESCRIPTION
## Summary
Added a development-only UI card that displays internal solar calculations for verification purposes. This allows engineers to sanity-check the underlying maths against source constants before shipping to production.

## Key Changes
- **New `DEV_MODE` flag** in `solar.js`: Controls visibility of the debug card. Set to `false` before production deployment.
- **New `buildSolarDebug()` function**: Generates a detailed breakdown of solar calculations including:
  - Self-consumption savings vs export earnings (annualized)
  - Monthly generation figures derived from `NZ_KWH_PER_KW_DAY` constants
  - Value erosion analysis showing nominal cumulative savings vs present value (discounting/inflation impact)
- **Enhanced `evaluateScenario()` function**: Now separately tracks `selfConsumptionSaving` and `exportEarning` to support the debug breakdown
- **New debug card in Dashboard**: Renders only when `DEV_MODE=true` and solar is applicable, displaying:
  - Annual savings breakdown (self-consumption + export)
  - Modelled generation per month with daily averages
  - Discounting/inflation erosion explanation with concrete figures
  - Generation table showing kWh per kW/day, average daily generation, and monthly totals

## Implementation Details
- The debug card uses existing styling conventions (`card-coral`, `solar-stats`, `plans-table`)
- Monthly generation calculations are independent of data span, derived purely from system size and `NZ_KWH_PER_KW_DAY` constants
- Discounting analysis leverages the existing `DISCOUNT_RATE` constant and payback calculation logic
- All monetary values are rounded and formatted with locale-aware thousand separators for readability

https://claude.ai/code/session_01RRmw3jMexR3mswc7yBDgyZ