### PR TITLE
Make solar breakdown card production-ready and customisable

### DIFF
--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useMemo } from "react";
 import {
   LineChart, Line, AreaChart, Area, BarChart, Bar,
   XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer,
@@ -8,7 +8,7 @@ import {
   dailyProfile, seasonalProfiles, weeklyTrend,
   generateInsights, currentAnnualCost, rankPlans,
 } from "../utils/analysis.js";
-import { batteryROI, solarROI, DISCOUNT_RATE, DEV_MODE } from "../utils/solar.js";
+import { batteryROI, solarROI, solarBreakdown, DISCOUNT_RATE, DEFAULT_LOAN_RATE, GREEN_LOAN_INTRO_RATE, GREEN_LOAN_INTRO_YEARS } from "../utils/solar.js";
 import { tariffsLastUpdated } from "../tariffs.js";
 import StepIndicator from "./StepIndicator.jsx";
 
@@ -126,6 +126,26 @@ export default function Dashboard({ data, currentTariff, onStepClick }) {
   const hasSolar = totalExportKwh > 1;
   const battery = hasSolar ? batteryROI(data, currentTariff) : null;
   const solar = hasSolar ? null : solarROI(data, currentTariff);
+
+  // Customisable inputs for the detailed breakdown card. Empty string means
+  // "use the recommended default" (best scenario size/cost, default loan rate).
+  const [sizeInput, setSizeInput] = useState("");
+  const [capexInput, setCapexInput] = useState("");
+  const [rateInput, setRateInput] = useState("");
+  const [greenLoan, setGreenLoan] = useState(false);
+
+  const breakdownSizeKw = sizeInput !== "" ? Number(sizeInput) : solar?.best?.sizeKw;
+  const breakdownCapex = capexInput !== "" ? Number(capexInput) : solar?.best?.capex;
+  const breakdownRate = rateInput !== "" ? Number(rateInput) / 100 : DEFAULT_LOAN_RATE;
+  const breakdown = useMemo(() => {
+    if (!solar || !solar.applicable) return null;
+    return solarBreakdown(data, currentTariff, {
+      sizeKw: breakdownSizeKw,
+      capex: breakdownCapex,
+      interestRate: breakdownRate,
+      greenLoan,
+    });
+  }, [solar, data, currentTariff, breakdownSizeKw, breakdownCapex, breakdownRate, greenLoan]);
 
   // Merge seasonal data for the overlay chart
   const seasonalMerged = profile.map((_, i) => ({
@@ -423,68 +443,119 @@ export default function Dashboard({ data, currentTariff, onStepClick }) {
           </section>
         )}
 
-        {/* ── DEV ONLY: Solar internal calculations (set DEV_MODE=false to hide) ── */}
-        {DEV_MODE && solar && solar.applicable && solar.debug && (
+        {/* ── Solar Maths Breakdown ── */}
+        {solar && solar.applicable && breakdown && (
           <section className="solar-section card-coral">
-            <h3>🛠️ Solar Maths Breakdown (dev only)</h3>
-            <p className="data-note" style={{ fontSize: "0.85rem", color: "#666", marginBottom: "0.5rem" }}>
-              Internal calculations for the best scenario ({solar.debug.label}),
-              shown so the figures can be verified. This card is hidden in
-              production (DEV_MODE = false).
+            <h3>Solar Maths Breakdown</h3>
+            <p className="chart-desc">
+              How the numbers above are built up, for a {breakdown.sizeKw} kW system
+              costing ${breakdown.capex.toLocaleString()}, modelled against your actual
+              half-hourly usage. Adjust the assumptions below to match a real quote.
             </p>
+
+            <div className="solar-customise">
+              <label className="solar-field">
+                <span>Solar system size (kW)</span>
+                <input
+                  type="number" min="0" step="0.5" inputMode="decimal"
+                  value={sizeInput} placeholder={String(solar.best.sizeKw)}
+                  onChange={(e) => setSizeInput(e.target.value)}
+                />
+              </label>
+              <label className="solar-field">
+                <span>System cost ($)</span>
+                <input
+                  type="number" min="0" step="500" inputMode="numeric"
+                  value={capexInput} placeholder={String(solar.best.capex)}
+                  onChange={(e) => setCapexInput(e.target.value)}
+                />
+              </label>
+              <label className="solar-field">
+                <span>Loan interest rate (%)</span>
+                <input
+                  type="number" min="0" step="0.1" inputMode="decimal"
+                  value={rateInput} placeholder={String(Math.round(DEFAULT_LOAN_RATE * 100))}
+                  onChange={(e) => setRateInput(e.target.value)}
+                />
+              </label>
+              <label className="solar-field solar-field-checkbox">
+                <input
+                  type="checkbox" checked={greenLoan}
+                  onChange={(e) => setGreenLoan(e.target.checked)}
+                />
+                <span>Green loan ({Math.round(GREEN_LOAN_INTRO_RATE * 100)}% for the
+                  first {GREEN_LOAN_INTRO_YEARS} years, then floating)</span>
+              </label>
+            </div>
 
             <div className="solar-stats">
               <div className="solar-stat">
                 <span className="solar-stat-label">Saving from self-consumption</span>
-                <span className="solar-stat-value">${Math.round(solar.debug.selfConsumptionSaving).toLocaleString()}/yr</span>
+                <span className="solar-stat-value">${Math.round(breakdown.selfConsumptionSaving).toLocaleString()}/yr</span>
               </div>
               <div className="solar-stat">
                 <span className="solar-stat-label">Earnings from export</span>
-                <span className="solar-stat-value">${Math.round(solar.debug.exportEarning).toLocaleString()}/yr</span>
+                <span className="solar-stat-value">${Math.round(breakdown.exportEarning).toLocaleString()}/yr</span>
               </div>
               <div className="solar-stat">
                 <span className="solar-stat-label">Total annual saving</span>
-                <span className="solar-stat-value">${Math.round(solar.debug.selfConsumptionSaving + solar.debug.exportEarning).toLocaleString()}/yr</span>
+                <span className="solar-stat-value">${Math.round(breakdown.annualSaving).toLocaleString()}/yr</span>
               </div>
               <div className="solar-stat">
                 <span className="solar-stat-label">Modelled annual generation</span>
-                <span className="solar-stat-value">{Math.round(solar.debug.annualGenerationKwh).toLocaleString()} kWh</span>
+                <span className="solar-stat-value">{Math.round(breakdown.annualGenerationKwh).toLocaleString()} kWh</span>
               </div>
             </div>
 
-            {solar.debug.inflation && (
-              <>
-                <h4 style={{ margin: "1rem 0 0.25rem" }}>Value lost to discounting / inflation</h4>
-                <p className="chart-desc" style={{ marginTop: 0 }}>
-                  Over the {solar.debug.inflation.paybackYears.toFixed(1)}-year payback you save
-                  ${Math.round(solar.debug.inflation.nominalCumulative).toLocaleString()} in nominal dollars,
-                  but at the {Math.round(DISCOUNT_RATE * 100)}% real discount rate those savings are only
-                  worth ${Math.round(solar.debug.inflation.presentValue).toLocaleString()} today (≈ the
-                  install cost). The difference,
-                  ${Math.round(solar.debug.inflation.lostToDiscounting).toLocaleString()}, is eroded by
-                  the time-value of money.
-                </p>
-              </>
-            )}
+            <h4 style={{ margin: "1rem 0 0.25rem" }}>Financing with a bank loan</h4>
+            <p className="chart-desc" style={{ marginTop: 0 }}>
+              {breakdown.loan.repaid ? (
+                <>
+                  Borrowing the ${breakdown.capex.toLocaleString()} on top of your mortgage
+                  {breakdown.loan.greenLoan
+                    ? ` at ${Math.round(GREEN_LOAN_INTRO_RATE * 100)}% for ${GREEN_LOAN_INTRO_YEARS} years then ${(breakdown.loan.floatingRate * 100).toFixed(1)}% floating`
+                    : ` at ${(breakdown.loan.floatingRate * 100).toFixed(1)}%`}
+                  , your ${Math.round(breakdown.annualSaving).toLocaleString()}/yr of savings
+                  pay it off in about {breakdown.loan.years.toFixed(1)} years.
+                  Total interest paid: ${Math.round(breakdown.loan.totalInterest).toLocaleString()}.
+                </>
+              ) : (
+                <>
+                  At {breakdown.loan.greenLoan
+                    ? `${Math.round(GREEN_LOAN_INTRO_RATE * 100)}% then ${(breakdown.loan.floatingRate * 100).toFixed(1)}% floating`
+                    : `${(breakdown.loan.floatingRate * 100).toFixed(1)}%`}
+                  , the ${Math.round(breakdown.annualSaving).toLocaleString()}/yr of savings don't
+                  cover the interest on a ${breakdown.capex.toLocaleString()} loan, so it never
+                  pays itself off — a lower rate or cheaper system is needed.
+                </>
+              )}
+            </p>
 
-            <h4 style={{ margin: "1rem 0 0.25rem" }}>Generation by month</h4>
+            <h4 style={{ margin: "1rem 0 0.25rem" }}>Average day by month</h4>
+            <p className="chart-desc" style={{ marginTop: 0 }}>
+              Per-day averages for each month, so you can see how much generation is
+              actually used at home versus exported. Self-consumption plus export equals
+              generation.
+            </p>
             <div className="table-wrapper">
               <table className="plans-table">
                 <thead>
                   <tr>
                     <th>Month</th>
-                    <th>kWh per kW/day</th>
-                    <th>Avg generation per day</th>
-                    <th>Total for the month</th>
+                    <th>Generation/day</th>
+                    <th>Consumption/day</th>
+                    <th>Self-consumed/day</th>
+                    <th>Exported/day</th>
                   </tr>
                 </thead>
                 <tbody>
-                  {solar.debug.months.map((m) => (
+                  {breakdown.months.map((m) => (
                     <tr key={m.month}>
                       <td className="retailer">{m.month}</td>
-                      <td>{m.kwhPerKwDay.toFixed(2)}</td>
-                      <td>{m.avgDailyKwh.toFixed(1)} kWh</td>
-                      <td>{Math.round(m.monthlyKwh).toLocaleString()} kWh</td>
+                      <td>{m.avgDailyGenerationKwh.toFixed(1)} kWh</td>
+                      <td>{m.avgDailyConsumptionKwh.toFixed(1)} kWh</td>
+                      <td>{m.avgDailySelfKwh.toFixed(1)} kWh</td>
+                      <td>{m.avgDailyExportKwh.toFixed(1)} kWh</td>
                     </tr>
                   ))}
                 </tbody>

--- a/src/index.css
+++ b/src/index.css
@@ -925,6 +925,44 @@ h3 {
   padding: 1.5rem;
 }
 
+.solar-customise {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  margin: 1rem 0;
+  padding: 1rem;
+  background: var(--coral-50);
+  border-radius: var(--radius-sm);
+}
+
+.solar-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  font-size: 0.8rem;
+  color: var(--grey-700);
+}
+
+.solar-field input[type="number"] {
+  padding: 0.4rem 0.5rem;
+  border: 1px solid var(--grey-200);
+  border-radius: var(--radius-sm);
+  font-size: 0.95rem;
+  width: 9rem;
+}
+
+.solar-field-checkbox {
+  flex-direction: row;
+  align-items: center;
+  gap: 0.5rem;
+  max-width: 22rem;
+  line-height: 1.4;
+}
+
+.solar-field-checkbox input {
+  flex: none;
+}
+
 .solar-stats {
   display: flex;
   flex-wrap: wrap;

--- a/src/utils/solar.js
+++ b/src/utils/solar.js
@@ -22,14 +22,17 @@
 
 import { matchesTou } from "./analysis.js";
 
-// Dev-only flag. While true the UI surfaces an internal-calculations card so
-// the underlying maths can be verified against real data. Set to false before
-// shipping to production to hide that card.
-export const DEV_MODE = true;
-
 // ─── Shared financial assumptions ───────────────────────────
 // Real discount rate used for the time-value-of-money payback.
 export const DISCOUNT_RATE = 0.05;
+
+// ─── Loan assumptions (breakdown card) ──────────────────────
+// Default bank-loan interest rate offered when financing a system, and the
+// "green loan" intro deal common in NZ: 1% for the first three years, then the
+// floating rate afterwards.
+export const DEFAULT_LOAN_RATE = 0.05;
+export const GREEN_LOAN_INTRO_RATE = 0.01;
+export const GREEN_LOAN_INTRO_YEARS = 3;
 // Horizon (years) over which we look for a discounted payback before giving up.
 const PAYBACK_HORIZON_YEARS = 40;
 
@@ -322,63 +325,10 @@ function generationForReading(timestamp, sizeKw) {
   return sizeKw * dailyPerKw * MONTH_WEIGHTS[m][slot];
 }
 
-// Days per month (Jan–Dec) for turning a daily generation figure into a
-// monthly total. Feb uses 28 — close enough for modelling.
-const DAYS_IN_MONTH = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
-
 const MONTH_NAMES = [
   "Jan", "Feb", "Mar", "Apr", "May", "Jun",
   "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
 ];
-
-/**
- * Build the dev-only internal-calculations breakdown for the chosen scenario,
- * so the maths can be sanity-checked against the source constants:
- *   - self-consumption saving vs export earning (annualised, from `best`)
- *   - modelled generation per month and per average day of that month, taken
- *     straight from NZ_KWH_PER_KW_DAY × system size (independent of data span)
- *   - value eroded by discounting/inflation: nominal cumulative savings over
- *     the payback period vs their present value (which equals the capex).
- */
-function buildSolarDebug(best) {
-  const sizeKw = best.sizeKw;
-  const months = MONTH_NAMES.map((name, m) => {
-    const avgDailyKwh = sizeKw * NZ_KWH_PER_KW_DAY[m];
-    return {
-      month: name,
-      kwhPerKwDay: NZ_KWH_PER_KW_DAY[m],
-      avgDailyKwh,
-      monthlyKwh: avgDailyKwh * DAYS_IN_MONTH[m],
-    };
-  });
-  const annualGenerationKwh = months.reduce((s, x) => s + x.monthlyKwh, 0);
-
-  // Discounting/inflation erosion over the payback period. By the definition of
-  // discounted payback the present value of savings at payback ≈ the capex, so
-  // the gap to the nominal sum is what time-value-of-money (inflation) erodes.
-  let inflation = null;
-  if (best.paybackYears != null) {
-    const nominalCumulative = best.annualSaving * best.paybackYears;
-    const presentValue = best.capex;
-    inflation = {
-      paybackYears: best.paybackYears,
-      annualSaving: best.annualSaving,
-      nominalCumulative,
-      presentValue,
-      lostToDiscounting: nominalCumulative - presentValue,
-    };
-  }
-
-  return {
-    sizeKw,
-    label: best.label,
-    selfConsumptionSaving: best.selfConsumptionSaving,
-    exportEarning: best.exportEarning,
-    months,
-    annualGenerationKwh,
-    inflation,
-  };
-}
 
 /** Annuity factor: present value of $1/year for `years` years at `rate`. */
 function annuityFactor(years, rate = DISCOUNT_RATE) {
@@ -418,16 +368,12 @@ function evaluateScenario(data, tariff, scenario, annualScale) {
     synthetic.push({ timestamp: r.timestamp, kwh: residualLoad, exportKwh: exported });
   }
 
-  const selfConsumptionSaving = (selfCents / 100) * annualScale;
-  const exportEarning = (exportCents / 100) * annualScale;
-  const annualSaving = selfConsumptionSaving + exportEarning;
+  const annualSaving = ((selfCents + exportCents) / 100) * annualScale;
   const paybackYears = discountedPayback(scenario.capex, annualSaving);
 
   return {
     ...scenario,
     annualSaving,
-    selfConsumptionSaving,
-    exportEarning,
     annualGenerationKwh: genKwh * annualScale,
     annualSurplusKwh: surplusKwh * annualScale,
     paybackYears,
@@ -531,6 +477,121 @@ export function solarROI(data, tariff) {
     loadShift,
     battery: battery.applicable ? battery : null,
     combined,
-    debug: DEV_MODE ? buildSolarDebug(best) : null,
+  };
+}
+
+// ─── Detailed breakdown (UI "Solar Maths Breakdown" card) ───
+//
+// Models a single, user-customisable system size/cost against the actual load,
+// broken down per calendar month, and presents the financing as a tangible
+// bank loan rather than an abstract discount rate.
+
+/**
+ * Years to fully repay `principal` when serviced by a fixed `annualRepayment`,
+ * with the outstanding balance accruing interest at `rateForYear(year)`.
+ * The accounting identity (total repaid − principal = total interest) holds for
+ * any rate schedule, so total interest is derived from the fractional term.
+ * Returns { repaid: false } if the repayment never clears the balance.
+ */
+function loanTerm(principal, annualRepayment, rateForYear, maxYears = 60) {
+  if (annualRepayment <= 0) {
+    return { repaid: false, years: null, totalInterest: null };
+  }
+  let balance = principal;
+  for (let y = 1; y <= maxYears; y++) {
+    const accrued = balance * (1 + rateForYear(y));
+    if (accrued <= annualRepayment) {
+      const years = y - 1 + accrued / annualRepayment;
+      return { repaid: true, years, totalInterest: annualRepayment * years - principal };
+    }
+    balance = accrued - annualRepayment;
+  }
+  return { repaid: false, years: null, totalInterest: null };
+}
+
+/**
+ * Per-month, per-average-day breakdown of generation, consumption, solar self-
+ * consumption and export for a given system size against the user's actual
+ * load, plus a bank-loan view of the economics.
+ *
+ * opts: { sizeKw, capex, interestRate (decimal), greenLoan (bool) }.
+ * Note that for every reading self-consumption + export equals generation, so
+ * the per-day self and export columns always sum to the generation column.
+ */
+export function solarBreakdown(data, tariff, opts = {}) {
+  if (!data || data.length === 0) return null;
+
+  const sizeKw = opts.sizeKw;
+  const capex = opts.capex;
+  const floatingRate = opts.interestRate ?? DEFAULT_LOAN_RATE;
+  const greenLoan = !!opts.greenLoan;
+  const exportRate = tariff.solarExportRate || 0;
+
+  const span = spanDays(data);
+  const annualScale = 365 / span;
+
+  const genSum = new Array(12).fill(0);
+  const loadSum = new Array(12).fill(0);
+  const selfSum = new Array(12).fill(0);
+  const exportSum = new Array(12).fill(0);
+  const dayKeys = Array.from({ length: 12 }, () => new Set());
+
+  let selfCents = 0;
+  let exportCents = 0;
+
+  for (const r of data) {
+    const m = r.timestamp.getMonth();
+    const load = r.kwh || 0;
+    const gen = generationForReading(r.timestamp, sizeKw);
+    const selfConsumed = Math.min(gen, load);
+    const exported = Math.max(0, gen - load);
+
+    genSum[m] += gen;
+    loadSum[m] += load;
+    selfSum[m] += selfConsumed;
+    exportSum[m] += exported;
+    dayKeys[m].add(dateKey(r.timestamp));
+
+    selfCents += selfConsumed * gridRateForReading(r.timestamp, tariff);
+    exportCents += exported * exportRate;
+  }
+
+  const months = MONTH_NAMES.map((name, m) => {
+    const days = dayKeys[m].size;
+    const div = days > 0 ? days : 1;
+    return {
+      month: name,
+      daysObserved: days,
+      avgDailyGenerationKwh: genSum[m] / div,
+      avgDailyConsumptionKwh: loadSum[m] / div,
+      avgDailySelfKwh: selfSum[m] / div,
+      avgDailyExportKwh: exportSum[m] / div,
+    };
+  });
+
+  const selfConsumptionSaving = (selfCents / 100) * annualScale;
+  const exportEarning = (exportCents / 100) * annualScale;
+  const annualSaving = selfConsumptionSaving + exportEarning;
+  const annualGenerationKwh = genSum.reduce((a, b) => a + b, 0) * annualScale;
+
+  const rateForYear = greenLoan
+    ? (y) => (y <= GREEN_LOAN_INTRO_YEARS ? GREEN_LOAN_INTRO_RATE : floatingRate)
+    : () => floatingRate;
+  const loan = {
+    ...loanTerm(capex, annualSaving, rateForYear),
+    floatingRate,
+    greenLoan,
+    annualRepayment: annualSaving,
+  };
+
+  return {
+    sizeKw,
+    capex,
+    selfConsumptionSaving,
+    exportEarning,
+    annualSaving,
+    annualGenerationKwh,
+    months,
+    loan,
   };
 }

--- a/test/solar.test.js
+++ b/test/solar.test.js
@@ -2,10 +2,12 @@ import { describe, it, expect } from "vitest";
 import {
   batteryROI,
   solarROI,
+  solarBreakdown,
   discountedPayback,
   gridRateForReading,
   SOLAR_SCENARIOS,
   DISCOUNT_RATE,
+  GREEN_LOAN_INTRO_YEARS,
 } from "../src/utils/solar.js";
 
 // ─── Data generators ─────────────────────────────────────────
@@ -215,5 +217,58 @@ describe("solarROI", () => {
     // so the battery model should at least run (applicable) on the synthetic data.
     expect(result.battery).not.toBeNull();
     expect(result.battery.applicable).toBe(true);
+  });
+});
+
+// ─── solarBreakdown ──────────────────────────────────────────
+
+describe("solarBreakdown", () => {
+  const yearLoad = buildData("2025-01-01T00:00:00", 365, () => ({ kwh: 0.4, exportKwh: 0 }));
+  const tariff = { baseRate: 32, touRates: [], solarExportRate: 10 };
+
+  it("returns 12 months and per-day self + export sums to generation", () => {
+    const b = solarBreakdown(yearLoad, tariff, { sizeKw: 5, capex: 11000, interestRate: 0.05 });
+    expect(b.months).toHaveLength(12);
+    for (const m of b.months) {
+      expect(m.avgDailySelfKwh + m.avgDailyExportKwh).toBeCloseTo(m.avgDailyGenerationKwh, 5);
+    }
+  });
+
+  it("summer months generate more per day than winter months", () => {
+    const b = solarBreakdown(yearLoad, tariff, { sizeKw: 5, capex: 11000, interestRate: 0.05 });
+    const jan = b.months[0].avgDailyGenerationKwh;
+    const jun = b.months[5].avgDailyGenerationKwh;
+    expect(jan).toBeGreaterThan(jun);
+  });
+
+  it("total annual saving equals self-consumption saving plus export earning", () => {
+    const b = solarBreakdown(yearLoad, tariff, { sizeKw: 5, capex: 11000, interestRate: 0.05 });
+    expect(b.annualSaving).toBeCloseTo(b.selfConsumptionSaving + b.exportEarning, 6);
+  });
+
+  it("models a loan whose total interest matches repaid minus principal", () => {
+    const b = solarBreakdown(yearLoad, tariff, { sizeKw: 8.5, capex: 16500, interestRate: 0.05 });
+    if (b.loan.repaid) {
+      const totalRepaid = b.loan.annualRepayment * b.loan.years;
+      expect(b.loan.totalInterest).toBeCloseTo(totalRepaid - b.capex, 4);
+    }
+  });
+
+  it("a green loan repays faster than the same loan at the floating rate", () => {
+    const opts = { sizeKw: 8.5, capex: 16500, interestRate: 0.07 };
+    const standard = solarBreakdown(yearLoad, tariff, opts);
+    const green = solarBreakdown(yearLoad, tariff, { ...opts, greenLoan: true });
+    if (standard.loan.repaid && green.loan.repaid) {
+      expect(green.loan.years).toBeLessThan(standard.loan.years);
+      expect(green.loan.totalInterest).toBeLessThan(standard.loan.totalInterest);
+    }
+    expect(GREEN_LOAN_INTRO_YEARS).toBe(3);
+  });
+
+  it("reports an unpayable loan when savings cannot cover interest", () => {
+    // Tiny system against trivial load → negligible saving, huge relative cost.
+    const b = solarBreakdown(yearLoad, tariff, { sizeKw: 0.01, capex: 100000, interestRate: 0.1 });
+    expect(b.loan.repaid).toBe(false);
+    expect(b.loan.years).toBeNull();
   });
 });


### PR DESCRIPTION
Remove the dev-only gate so the breakdown ships in production. Add a per-average-day monthly table (generation, consumption, self-consumption, export) so the user can see how much generation is actually utilised. Reframe the time-value-of-money figure as a tangible bank loan (annual savings service the loan; show payback time and total interest), with a customise panel to set system size, cost, and loan rate — including a green-loan option (1% for three years, then floating).

https://claude.ai/code/session_01RRmw3jMexR3mswc7yBDgyZ