### PR TITLE
Add autofill defaults for missing tariff fields with confirmation modal

### DIFF
--- a/src/components/TariffReview.jsx
+++ b/src/components/TariffReview.jsx
@@ -4,6 +4,15 @@ const DAY_LABELS = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
 // JS getDay(): 0=Sun,1=Mon,...,6=Sat  →  our checkbox index: 0=Mon,...,6=Sun
 const DAY_INDEX_TO_JS = [1, 2, 3, 4, 5, 6, 0];
 
+// Defaults applied when the user leaves a field blank before running analysis.
+const DEFAULTS = {
+  dailyCharge: { value: 230, label: "daily fixed charge", unit: "cents/day" },
+  baseRate: { value: 28.5, label: "base rate", unit: "cents/kWh" },
+  solarExportRate: { value: 12.5, label: "solar export rate", unit: "cents/kWh" },
+};
+
+const isBlank = (v) => v === "" || v == null;
+
 function emptyTouRate() {
   return { rate: "", startHour: 7, endHour: 21, days: [1, 2, 3, 4, 5, 6, 0] };
 }
@@ -41,10 +50,10 @@ export default function TariffReview({ extractedTariff, confirmedTariff, onConfi
       ? confirmedTariff.solarExportRate
       : extractedTariff.solarExportRate) ?? "";
   const [solarExportRate, setSolarExportRate] = useState(initialExportRate);
-  // Show the field expanded if a rate was detected or previously entered.
-  const [showSolarExport, setShowSolarExport] = useState(
-    initialExportRate !== "" && initialExportRate != null
-  );
+
+  // Fields that were autofilled with defaults, shown in a confirmation modal.
+  const [autofillNotice, setAutofillNotice] = useState(null);
+  const [pendingTariff, setPendingTariff] = useState(null);
 
   const update = (field) => (e) =>
     setTariff((t) => ({ ...t, [field]: e.target.value }));
@@ -77,14 +86,21 @@ export default function TariffReview({ extractedTariff, confirmedTariff, onConfi
   const removeTouRate = (index) =>
     setTouRates((prev) => prev.filter((_, i) => i !== index));
 
-  const handleConfirm = () => {
-    const exportRate =
-      showSolarExport && solarExportRate !== "" && solarExportRate != null
-        ? parseFloat(solarExportRate) || 0
-        : null;
-    onConfirm({
-      dailyCharge: parseFloat(tariff.dailyCharge) || 0,
-      baseRate: parseFloat(tariff.baseRate) || 0,
+  const buildTariff = () => {
+    const autofilled = [];
+
+    const resolve = (field, raw) => {
+      if (isBlank(raw)) {
+        autofilled.push(DEFAULTS[field]);
+        return DEFAULTS[field].value;
+      }
+      return parseFloat(raw) || 0;
+    };
+
+    const result = {
+      dailyCharge: resolve("dailyCharge", tariff.dailyCharge),
+      baseRate: resolve("baseRate", tariff.baseRate),
+      // Time of use rates are left blank if not filled out (no default).
       touRates: touRates
         .filter((t) => t.rate !== "" && t.rate != null)
         .map((t) => ({
@@ -93,8 +109,25 @@ export default function TariffReview({ extractedTariff, confirmedTariff, onConfi
           endHour: parseInt(t.endHour) || 0,
           days: t.days,
         })),
-      solarExportRate: exportRate,
-    });
+      solarExportRate: resolve("solarExportRate", solarExportRate),
+    };
+
+    return { result, autofilled };
+  };
+
+  const handleConfirm = () => {
+    const { result, autofilled } = buildTariff();
+    if (autofilled.length > 0) {
+      setPendingTariff(result);
+      setAutofillNotice(autofilled);
+    } else {
+      onConfirm(result);
+    }
+  };
+
+  const acceptAutofill = () => {
+    setAutofillNotice(null);
+    onConfirm(pendingTariff);
   };
 
   return (
@@ -144,6 +177,15 @@ export default function TariffReview({ extractedTariff, confirmedTariff, onConfi
         <div className="form-row">
           <label>Base rate (cents/kWh)</label>
           <input type="number" value={tariff.baseRate} onChange={update("baseRate")} placeholder="e.g. 28.5" />
+        </div>
+        <div className="form-row">
+          <label>Solar export rate (cents/kWh)</label>
+          <input
+            type="number"
+            value={solarExportRate}
+            onChange={(e) => setSolarExportRate(e.target.value)}
+            placeholder="e.g. 12.5"
+          />
         </div>
 
         {/* ── Time-of-Use Rates ── */}
@@ -225,51 +267,43 @@ export default function TariffReview({ extractedTariff, confirmedTariff, onConfi
             + Add Time of Use Rate
           </button>
         </div>
-
-        {/* ── Solar export (buy-back) rate ── */}
-        <div className="solar-export-section">
-          <h3>Solar Export</h3>
-          {showSolarExport ? (
-            <>
-              <p className="tou-hint">
-                The rate your retailer pays for electricity you export to the
-                grid (cents/kWh). Used to assess solar and battery economics.
-              </p>
-              <div className="form-row">
-                <label>Solar export rate (cents/kWh)</label>
-                <input
-                  type="number"
-                  value={solarExportRate}
-                  onChange={(e) => setSolarExportRate(e.target.value)}
-                  placeholder="e.g. 12.5"
-                />
-              </div>
-              <button
-                className="tou-remove-btn"
-                type="button"
-                onClick={() => {
-                  setShowSolarExport(false);
-                  setSolarExportRate("");
-                }}
-              >
-                Remove
-              </button>
-            </>
-          ) : (
-            <button
-              className="secondary-btn"
-              type="button"
-              onClick={() => setShowSolarExport(true)}
-            >
-              + Add solar export rate
-            </button>
-          )}
-        </div>
       </div>
 
       <button className="primary-btn" onClick={handleConfirm}>
         Run Analysis
       </button>
+
+      {autofillNotice && (
+        <div className="autofill-overlay" role="dialog" aria-modal="true">
+          <div className="autofill-modal">
+            <h3>Missing tariff values</h3>
+            {autofillNotice.length === 1 ? (
+              <p>
+                You haven't entered data for the {autofillNotice[0].label}, so
+                we've autofilled it with a default of {autofillNotice[0].value}{" "}
+                {autofillNotice[0].unit}.
+              </p>
+            ) : (
+              <>
+                <p>
+                  You haven't entered data for some fields, so we've autofilled
+                  them with these defaults:
+                </p>
+                <ul>
+                  {autofillNotice.map((f) => (
+                    <li key={f.label}>
+                      {f.label}: {f.value} {f.unit}
+                    </li>
+                  ))}
+                </ul>
+              </>
+            )}
+            <button className="primary-btn" onClick={acceptAutofill}>
+              Continue to Analysis
+            </button>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/index.css
+++ b/src/index.css
@@ -676,6 +676,47 @@ h3 {
   color: var(--coral-700);
 }
 
+/* ── Autofill Notice Modal ────────────────────────────── */
+.autofill-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(12, 26, 50, 0.55);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+  z-index: 100;
+}
+
+.autofill-modal {
+  background: #fff;
+  border-radius: var(--radius-md);
+  padding: 1.75rem;
+  max-width: 440px;
+  width: 100%;
+  box-shadow: 0 20px 50px rgba(12, 26, 50, 0.3);
+}
+
+.autofill-modal h3 {
+  margin-bottom: 0.75rem;
+  color: var(--navy-900);
+}
+
+.autofill-modal p {
+  color: var(--grey-700);
+  margin-bottom: 0.75rem;
+}
+
+.autofill-modal ul {
+  margin: 0 0 1rem;
+  padding-left: 1.25rem;
+}
+
+.autofill-modal li {
+  color: var(--grey-700);
+  margin-bottom: 0.25rem;
+}
+
 .csv-preview {
   margin-top: 0.75rem;
   overflow-x: auto;


### PR DESCRIPTION
## Summary
This PR improves the tariff review experience by introducing sensible defaults for missing tariff fields. When users attempt to run analysis without entering values for daily charge, base rate, or solar export rate, the system now automatically fills these fields with industry-standard defaults and displays a confirmation modal before proceeding.

## Key Changes
- **Added default tariff values**: Introduced a `DEFAULTS` constant with sensible defaults for daily charge (230 cents/day), base rate (28.5 cents/kWh), and solar export rate (12.5 cents/kWh)
- **Refactored tariff building logic**: Extracted tariff construction into a new `buildTariff()` function that tracks which fields were autofilled
- **Implemented autofill confirmation modal**: When any fields are autofilled, a modal dialog displays the defaults to the user before confirming the analysis
- **Simplified solar export field**: Removed the conditional show/hide toggle for the solar export rate field—it's now always visible as a standard form input, making the UI more straightforward
- **Added modal styling**: Implemented accessible modal styling with overlay, proper z-indexing, and responsive design

## Notable Implementation Details
- The `isBlank()` helper function handles both empty strings and null values consistently
- The `buildTariff()` function returns both the resolved tariff object and a list of autofilled fields for display
- The modal uses semantic HTML (`role="dialog"`, `aria-modal="true"`) for accessibility
- Single vs. multiple autofilled fields are handled with conditional rendering for better UX messaging
- Time-of-use rates continue to have no defaults and are only included if explicitly entered

https://claude.ai/code/session_01DyyarBVgZcVsAQa8a5r3td