### PR TITLE
Extend solar breakdown: savings/day, payback box, custom row, export …

### DIFF
--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -132,20 +132,27 @@ export default function Dashboard({ data, currentTariff, onStepClick }) {
   const [sizeInput, setSizeInput] = useState("");
   const [capexInput, setCapexInput] = useState("");
   const [rateInput, setRateInput] = useState("");
+  const [exportInput, setExportInput] = useState("");
   const [greenLoan, setGreenLoan] = useState(false);
 
+  const defaultExportRate = currentTariff.solarExportRate || 0;
   const breakdownSizeKw = sizeInput !== "" ? Number(sizeInput) : solar?.best?.sizeKw;
   const breakdownCapex = capexInput !== "" ? Number(capexInput) : solar?.best?.capex;
   const breakdownRate = rateInput !== "" ? Number(rateInput) / 100 : DEFAULT_LOAN_RATE;
+  const breakdownExportRate = exportInput !== "" ? Number(exportInput) : defaultExportRate;
+  // A custom row is shown in the comparison table when the system or export
+  // assumptions (the things that move the table's columns) have been changed.
+  const breakdownCustomised = sizeInput !== "" || capexInput !== "" || exportInput !== "";
   const breakdown = useMemo(() => {
     if (!solar || !solar.applicable) return null;
     return solarBreakdown(data, currentTariff, {
       sizeKw: breakdownSizeKw,
       capex: breakdownCapex,
       interestRate: breakdownRate,
+      exportRate: breakdownExportRate,
       greenLoan,
     });
-  }, [solar, data, currentTariff, breakdownSizeKw, breakdownCapex, breakdownRate, greenLoan]);
+  }, [solar, data, currentTariff, breakdownSizeKw, breakdownCapex, breakdownRate, breakdownExportRate, greenLoan]);
 
   // Merge seasonal data for the overlay chart
   const seasonalMerged = profile.map((_, i) => ({
@@ -407,6 +414,15 @@ export default function Dashboard({ data, currentTariff, onStepClick }) {
                       <td>{s.paybackYears != null ? `${s.paybackYears.toFixed(1)} yrs` : "> 40 yrs"}</td>
                     </tr>
                   ))}
+                  {breakdownCustomised && breakdown && (
+                    <tr className="custom-row">
+                      <td className="retailer">{breakdown.sizeKw} kW (custom)</td>
+                      <td>${Math.round(breakdown.capex).toLocaleString()}</td>
+                      <td>{Math.round(breakdown.annualGenerationKwh).toLocaleString()} kWh</td>
+                      <td>${Math.round(breakdown.annualSaving).toLocaleString()}</td>
+                      <td>{breakdown.paybackYears != null ? `${breakdown.paybackYears.toFixed(1)} yrs` : "> 40 yrs"}</td>
+                    </tr>
+                  )}
                 </tbody>
               </table>
             </div>
@@ -471,6 +487,14 @@ export default function Dashboard({ data, currentTariff, onStepClick }) {
                 />
               </label>
               <label className="solar-field">
+                <span>Solar export rate (c/kWh)</span>
+                <input
+                  type="number" min="0" step="0.5" inputMode="decimal"
+                  value={exportInput} placeholder={String(defaultExportRate)}
+                  onChange={(e) => setExportInput(e.target.value)}
+                />
+              </label>
+              <label className="solar-field">
                 <span>Loan interest rate (%)</span>
                 <input
                   type="number" min="0" step="0.1" inputMode="decimal"
@@ -504,6 +528,12 @@ export default function Dashboard({ data, currentTariff, onStepClick }) {
               <div className="solar-stat">
                 <span className="solar-stat-label">Modelled annual generation</span>
                 <span className="solar-stat-value">{Math.round(breakdown.annualGenerationKwh).toLocaleString()} kWh</span>
+              </div>
+              <div className="solar-stat">
+                <span className="solar-stat-label">Payback period</span>
+                <span className="solar-stat-value">
+                  {breakdown.loan.repaid ? `${breakdown.loan.years.toFixed(1)} years` : "> 60 years"}
+                </span>
               </div>
             </div>
 
@@ -546,6 +576,7 @@ export default function Dashboard({ data, currentTariff, onStepClick }) {
                     <th>Consumption/day</th>
                     <th>Self-consumed/day</th>
                     <th>Exported/day</th>
+                    <th>Savings/day</th>
                   </tr>
                 </thead>
                 <tbody>
@@ -556,6 +587,7 @@ export default function Dashboard({ data, currentTariff, onStepClick }) {
                       <td>{m.avgDailyConsumptionKwh.toFixed(1)} kWh</td>
                       <td>{m.avgDailySelfKwh.toFixed(1)} kWh</td>
                       <td>{m.avgDailyExportKwh.toFixed(1)} kWh</td>
+                      <td>${m.avgDailySavingsDollars.toFixed(2)}</td>
                     </tr>
                   ))}
                 </tbody>

--- a/src/index.css
+++ b/src/index.css
@@ -1061,6 +1061,11 @@ h3 {
   background: var(--green-100);
 }
 
+.plans-table tr.custom-row td {
+  background: var(--coral-50);
+  font-style: italic;
+}
+
 .plans-table td.positive {
   color: var(--green-600);
   font-weight: 600;

--- a/src/utils/solar.js
+++ b/src/utils/solar.js
@@ -525,7 +525,7 @@ export function solarBreakdown(data, tariff, opts = {}) {
   const capex = opts.capex;
   const floatingRate = opts.interestRate ?? DEFAULT_LOAN_RATE;
   const greenLoan = !!opts.greenLoan;
-  const exportRate = tariff.solarExportRate || 0;
+  const exportRate = opts.exportRate ?? (tariff.solarExportRate || 0);
 
   const span = spanDays(data);
   const annualScale = 365 / span;
@@ -534,6 +534,7 @@ export function solarBreakdown(data, tariff, opts = {}) {
   const loadSum = new Array(12).fill(0);
   const selfSum = new Array(12).fill(0);
   const exportSum = new Array(12).fill(0);
+  const saveCents = new Array(12).fill(0);
   const dayKeys = Array.from({ length: 12 }, () => new Set());
 
   let selfCents = 0;
@@ -552,8 +553,11 @@ export function solarBreakdown(data, tariff, opts = {}) {
     exportSum[m] += exported;
     dayKeys[m].add(dateKey(r.timestamp));
 
-    selfCents += selfConsumed * gridRateForReading(r.timestamp, tariff);
-    exportCents += exported * exportRate;
+    const selfValue = selfConsumed * gridRateForReading(r.timestamp, tariff);
+    const exportValue = exported * exportRate;
+    selfCents += selfValue;
+    exportCents += exportValue;
+    saveCents[m] += selfValue + exportValue;
   }
 
   const months = MONTH_NAMES.map((name, m) => {
@@ -566,6 +570,7 @@ export function solarBreakdown(data, tariff, opts = {}) {
       avgDailyConsumptionKwh: loadSum[m] / div,
       avgDailySelfKwh: selfSum[m] / div,
       avgDailyExportKwh: exportSum[m] / div,
+      avgDailySavingsDollars: saveCents[m] / 100 / div,
     };
   });
 
@@ -587,10 +592,12 @@ export function solarBreakdown(data, tariff, opts = {}) {
   return {
     sizeKw,
     capex,
+    exportRate,
     selfConsumptionSaving,
     exportEarning,
     annualSaving,
     annualGenerationKwh,
+    paybackYears: discountedPayback(capex, annualSaving),
     months,
     loan,
   };

--- a/test/solar.test.js
+++ b/test/solar.test.js
@@ -246,6 +246,22 @@ describe("solarBreakdown", () => {
     expect(b.annualSaving).toBeCloseTo(b.selfConsumptionSaving + b.exportEarning, 6);
   });
 
+  it("exposes a per-day savings figure and a discounted payback for the table", () => {
+    const b = solarBreakdown(yearLoad, tariff, { sizeKw: 5, capex: 11000, interestRate: 0.05 });
+    for (const m of b.months) {
+      expect(m.avgDailySavingsDollars).toBeGreaterThanOrEqual(0);
+    }
+    // The discounted payback should match the standalone helper at the same rate.
+    expect(b.paybackYears).toBeCloseTo(discountedPayback(11000, b.annualSaving), 4);
+  });
+
+  it("an export-rate override changes export earnings", () => {
+    const low = solarBreakdown(yearLoad, tariff, { sizeKw: 5, capex: 11000, exportRate: 5 });
+    const high = solarBreakdown(yearLoad, tariff, { sizeKw: 5, capex: 11000, exportRate: 20 });
+    expect(high.exportEarning).toBeGreaterThan(low.exportEarning);
+    expect(high.exportRate).toBe(20);
+  });
+
   it("models a loan whose total interest matches repaid minus principal", () => {
     const b = solarBreakdown(yearLoad, tariff, { sizeKw: 8.5, capex: 16500, interestRate: 0.05 });
     if (b.loan.repaid) {


### PR DESCRIPTION
…rate

- Add a per-day dollar savings column to the monthly breakdown table.
- Add a "Payback period" stat box alongside the savings/generation stats.
- Show a pink-highlighted custom row in the solar comparison table whenever the system size, cost or export rate is customised.
- Add a solar export rate input to the customise panel, overriding the tariff's rate for the modelled economics.

https://claude.ai/code/session_01RRmw3jMexR3mswc7yBDgyZ