### PR TITLE
Fix scroll position and input field placeholder behavior

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,4 @@
-import { useState, useCallback } from "react";
+import { useState, useCallback, useEffect } from "react";
 import UploadScreen from "./components/UploadScreen.jsx";
 import TariffReview from "./components/TariffReview.jsx";
 import Dashboard from "./components/Dashboard.jsx";
@@ -15,6 +15,12 @@ import { extractTariffFromPDF } from "./utils/pdfParser.js";
 export default function App() {
   // "upload" | "review" | "dashboard"
   const [step, setStep] = useState("upload");
+
+  // Each step transition (e.g. Run Analysis → dashboard) should start at the
+  // top of the page rather than wherever the previous step was scrolled to.
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [step]);
 
   const [consumptionData, setConsumptionData] = useState(null);
   const [csvWarnings, setCsvWarnings] = useState([]);

--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -474,7 +474,7 @@ export default function Dashboard({ data, currentTariff, onStepClick }) {
                 <span>Solar system size (kW)</span>
                 <input
                   type="number" min="0" step="0.5" inputMode="decimal"
-                  value={sizeInput} placeholder={String(solar.best.sizeKw)}
+                  value={sizeInput !== "" ? sizeInput : String(solar.best.sizeKw)}
                   onChange={(e) => setSizeInput(e.target.value)}
                 />
               </label>
@@ -482,7 +482,7 @@ export default function Dashboard({ data, currentTariff, onStepClick }) {
                 <span>System cost ($)</span>
                 <input
                   type="number" min="0" step="500" inputMode="numeric"
-                  value={capexInput} placeholder={String(solar.best.capex)}
+                  value={capexInput !== "" ? capexInput : String(solar.best.capex)}
                   onChange={(e) => setCapexInput(e.target.value)}
                 />
               </label>
@@ -490,7 +490,7 @@ export default function Dashboard({ data, currentTariff, onStepClick }) {
                 <span>Solar export rate (c/kWh)</span>
                 <input
                   type="number" min="0" step="0.5" inputMode="decimal"
-                  value={exportInput} placeholder={String(defaultExportRate)}
+                  value={exportInput !== "" ? exportInput : String(defaultExportRate)}
                   onChange={(e) => setExportInput(e.target.value)}
                 />
               </label>
@@ -498,7 +498,7 @@ export default function Dashboard({ data, currentTariff, onStepClick }) {
                 <span>Loan interest rate (%)</span>
                 <input
                   type="number" min="0" step="0.1" inputMode="decimal"
-                  value={rateInput} placeholder={String(Math.round(DEFAULT_LOAN_RATE * 100))}
+                  value={rateInput !== "" ? rateInput : String(Math.round(DEFAULT_LOAN_RATE * 100))}
                   onChange={(e) => setRateInput(e.target.value)}
                 />
               </label>


### PR DESCRIPTION
## Summary
This PR addresses two UX issues: scroll position not resetting between page transitions, and input field placeholders not displaying correctly when fields are cleared.

## Key Changes
- **Auto-scroll to top on step transitions**: Added a `useEffect` hook that scrolls to the top of the page whenever the `step` state changes, ensuring users start at the top when navigating between upload, review, and dashboard screens.
- **Fixed input placeholder display**: Changed four solar configuration input fields in the Dashboard to use conditional rendering (`value={input !== "" ? input : placeholder}`) instead of the `placeholder` attribute. This ensures the default values display correctly when the input is empty, improving the UX for users who clear fields.

## Implementation Details
- The scroll effect uses `window.scrollTo(0, 0)` with `step` as the dependency, triggering on every step change.
- The input field fix applies to: Solar system size, System cost, Solar export rate, and Loan interest rate inputs.
- This change maintains the same visual behavior while ensuring placeholder values are always visible when appropriate.

https://claude.ai/code/session_01NB2x8WcXCrZagt81NyUQqg