### PR TITLE
Highlight solar payback period with prominent styling

### DIFF
--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -401,7 +401,7 @@ export default function Dashboard({ data, currentTariff, onStepClick }) {
                     <th>Installed cost</th>
                     <th>Annual generation</th>
                     <th>Annual saving</th>
-                    <th>Payback ({Math.round(DISCOUNT_RATE * 100)}%)</th>
+                    <th>Payback</th>
                   </tr>
                 </thead>
                 <tbody>
@@ -420,7 +420,7 @@ export default function Dashboard({ data, currentTariff, onStepClick }) {
                       <td>${Math.round(breakdown.capex).toLocaleString()}</td>
                       <td>{Math.round(breakdown.annualGenerationKwh).toLocaleString()} kWh</td>
                       <td>${Math.round(breakdown.annualSaving).toLocaleString()}</td>
-                      <td>{breakdown.paybackYears != null ? `${breakdown.paybackYears.toFixed(1)} yrs` : "> 40 yrs"}</td>
+                      <td>{breakdown.loan.repaid ? `${breakdown.loan.years.toFixed(1)} yrs` : "> 60 yrs"}</td>
                     </tr>
                   )}
                 </tbody>
@@ -513,6 +513,12 @@ export default function Dashboard({ data, currentTariff, onStepClick }) {
             </div>
 
             <div className="solar-stats">
+              <div className="solar-stat solar-stat-payback">
+                <span className="solar-stat-label">Payback period</span>
+                <span className="solar-stat-value">
+                  {breakdown.loan.repaid ? `${breakdown.loan.years.toFixed(1)} years` : "> 60 years"}
+                </span>
+              </div>
               <div className="solar-stat">
                 <span className="solar-stat-label">Saving from self-consumption</span>
                 <span className="solar-stat-value">${Math.round(breakdown.selfConsumptionSaving).toLocaleString()}/yr</span>
@@ -528,12 +534,6 @@ export default function Dashboard({ data, currentTariff, onStepClick }) {
               <div className="solar-stat">
                 <span className="solar-stat-label">Modelled annual generation</span>
                 <span className="solar-stat-value">{Math.round(breakdown.annualGenerationKwh).toLocaleString()} kWh</span>
-              </div>
-              <div className="solar-stat">
-                <span className="solar-stat-label">Payback period</span>
-                <span className="solar-stat-value">
-                  {breakdown.loan.repaid ? `${breakdown.loan.years.toFixed(1)} years` : "> 60 years"}
-                </span>
               </div>
             </div>
 

--- a/src/index.css
+++ b/src/index.css
@@ -1032,6 +1032,18 @@ h3 {
   color: var(--grey-800);
 }
 
+.solar-stat-payback {
+  background: var(--coral-500);
+}
+
+.solar-stat-payback .solar-stat-label {
+  color: var(--coral-100);
+}
+
+.solar-stat-payback .solar-stat-value {
+  color: #fff;
+}
+
 .solar-verdict {
   margin-top: 1rem;
   padding: 0.85rem 1rem;
@@ -1251,5 +1263,32 @@ h3 {
 
   .step-indicator {
     padding: 0.5rem 1rem;
+  }
+
+  .solar-section {
+    padding: 1rem;
+  }
+
+  .solar-stats {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 0.5rem;
+  }
+
+  .solar-stat {
+    min-width: 0;
+    padding: 0.5rem 0.6rem;
+  }
+
+  .solar-stat-label {
+    font-size: 0.7rem;
+  }
+
+  .solar-stat-value {
+    font-size: 0.95rem;
+  }
+
+  .solar-stat-payback {
+    grid-column: 1 / -1;
   }
 }


### PR DESCRIPTION
## Summary
This PR enhances the solar payback period display by giving it visual prominence through dedicated styling and repositioning it as the first stat in the solar stats section.

## Key Changes
- **Added `.solar-stat-payback` CSS class** with coral background color to visually distinguish the payback period stat from other metrics
- **Repositioned payback period** to appear first in the solar stats grid with full-width layout on mobile devices
- **Updated responsive design** to display solar stats in a 2-column grid on mobile, with the payback stat spanning both columns
- **Removed discount rate reference** from the payback table header (changed from "Payback (X%)" to "Payback")
- **Updated payback threshold** from "> 40 yrs" to "> 60 yrs" for consistency with the new loan-based calculation model
- **Refactored payback calculation logic** to use `breakdown.loan.repaid` and `breakdown.loan.years` instead of `breakdown.paybackYears`

## Implementation Details
- The payback stat now uses a coral color scheme (`--coral-500` background with `--coral-100` label text and white value text) to make it stand out
- Mobile responsive adjustments include reduced padding and font sizes for the solar stats section
- The payback period stat uses `grid-column: 1 / -1` on mobile to span the full width of the 2-column grid

https://claude.ai/code/session_018PA5xkwgQ5Aa8FtQnUXs9D