### PR TITLE
Add load-shifting input to the solar calculator

### DIFF
--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -133,6 +133,7 @@ export default function Dashboard({ data, currentTariff, onStepClick }) {
   const [capexInput, setCapexInput] = useState("");
   const [rateInput, setRateInput] = useState("");
   const [exportInput, setExportInput] = useState("");
+  const [loadShiftInput, setLoadShiftInput] = useState("");
   const [greenLoan, setGreenLoan] = useState(false);
 
   const defaultExportRate = currentTariff.solarExportRate || 0;
@@ -140,9 +141,11 @@ export default function Dashboard({ data, currentTariff, onStepClick }) {
   const breakdownCapex = capexInput !== "" ? Number(capexInput) : solar?.best?.capex;
   const breakdownRate = rateInput !== "" ? Number(rateInput) / 100 : DEFAULT_LOAN_RATE;
   const breakdownExportRate = exportInput !== "" ? Number(exportInput) : defaultExportRate;
-  // A custom row is shown in the comparison table when the system or export
-  // assumptions (the things that move the table's columns) have been changed.
-  const breakdownCustomised = sizeInput !== "" || capexInput !== "" || exportInput !== "";
+  const breakdownLoadShift = loadShiftInput !== "" ? Number(loadShiftInput) : 0;
+  // A custom row is shown in the comparison table when the system, export or
+  // load-shift assumptions (the things that move the table's columns) change.
+  const breakdownCustomised =
+    sizeInput !== "" || capexInput !== "" || exportInput !== "" || loadShiftInput !== "";
   const breakdown = useMemo(() => {
     if (!solar || !solar.applicable) return null;
     return solarBreakdown(data, currentTariff, {
@@ -150,9 +153,10 @@ export default function Dashboard({ data, currentTariff, onStepClick }) {
       capex: breakdownCapex,
       interestRate: breakdownRate,
       exportRate: breakdownExportRate,
+      loadShiftPercent: breakdownLoadShift,
       greenLoan,
     });
-  }, [solar, data, currentTariff, breakdownSizeKw, breakdownCapex, breakdownRate, breakdownExportRate, greenLoan]);
+  }, [solar, data, currentTariff, breakdownSizeKw, breakdownCapex, breakdownRate, breakdownExportRate, breakdownLoadShift, greenLoan]);
 
   // Merge seasonal data for the overlay chart
   const seasonalMerged = profile.map((_, i) => ({
@@ -500,6 +504,38 @@ export default function Dashboard({ data, currentTariff, onStepClick }) {
                   type="number" min="0" step="0.1" inputMode="decimal"
                   value={rateInput !== "" ? rateInput : String(Math.round(DEFAULT_LOAN_RATE * 100))}
                   onChange={(e) => setRateInput(e.target.value)}
+                />
+              </label>
+              <label className="solar-field">
+                <span className="solar-field-label">
+                  Load shifting (%)
+                  <span className="info-tooltip" tabIndex={0}>
+                    <span className="info-tooltip-icon" aria-hidden="true">?</span>
+                    <span className="info-tooltip-bubble" role="tooltip">
+                      <strong>What is load shifting?</strong>
+                      <span>
+                        Moving energy use from outside sunlit hours into the middle
+                        of the day so it runs off your own solar instead of the grid.
+                        It doesn&apos;t reduce how much you use — it just reshapes when.
+                      </span>
+                      <span>
+                        0% = no change. 100% = every bit of out-of-sun load is
+                        spread evenly across daylight hours. Indicative figures for a
+                        home with no controls today:
+                      </span>
+                      <span>
+                        • Dishwasher run during the day: <strong>~5%</strong><br />
+                        • Timer on the hot-water cylinder: <strong>~25%</strong><br />
+                        • EV charged during the day, not overnight: <strong>~50%</strong>
+                      </span>
+                      <span>Stack these up if more than one applies to you.</span>
+                    </span>
+                  </span>
+                </span>
+                <input
+                  type="number" min="0" max="100" step="5" inputMode="numeric"
+                  value={loadShiftInput !== "" ? loadShiftInput : "0"}
+                  onChange={(e) => setLoadShiftInput(e.target.value)}
                 />
               </label>
               <label className="solar-field solar-field-checkbox">

--- a/src/index.css
+++ b/src/index.css
@@ -992,6 +992,63 @@ h3 {
   width: 9rem;
 }
 
+.solar-field-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.info-tooltip {
+  position: relative;
+  display: inline-flex;
+  cursor: help;
+  outline: none;
+}
+
+.info-tooltip-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.05rem;
+  height: 1.05rem;
+  border-radius: 50%;
+  background: var(--coral-500);
+  color: #fff;
+  font-size: 0.7rem;
+  font-weight: 700;
+  line-height: 1;
+}
+
+.info-tooltip-bubble {
+  position: absolute;
+  bottom: calc(100% + 0.5rem);
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 20;
+  display: none;
+  flex-direction: column;
+  gap: 0.4rem;
+  width: 17rem;
+  padding: 0.75rem 0.85rem;
+  background: var(--grey-700, #334155);
+  color: #fff;
+  border-radius: var(--radius-sm);
+  font-size: 0.78rem;
+  font-weight: 400;
+  line-height: 1.4;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.25);
+}
+
+.info-tooltip-bubble strong {
+  font-weight: 700;
+}
+
+.info-tooltip:hover .info-tooltip-bubble,
+.info-tooltip:focus .info-tooltip-bubble,
+.info-tooltip:focus-within .info-tooltip-bubble {
+  display: flex;
+}
+
 .solar-field-checkbox {
   flex-direction: row;
   align-items: center;

--- a/src/utils/solar.js
+++ b/src/utils/solar.js
@@ -96,6 +96,56 @@ function isAfterSunset(timestamp) {
   return hourFloat >= NZ_SUNSET_HOUR[timestamp.getMonth()];
 }
 
+/** Is this reading within the solar daylight window for its month? */
+function isDaylight(timestamp) {
+  const [start, end] = NZ_DAYLIGHT[timestamp.getMonth()];
+  const hourFloat = timestamp.getHours() + timestamp.getMinutes() / 60;
+  return hourFloat >= start && hourFloat < end;
+}
+
+/**
+ * Load shifting (issue #50): move a fraction of each day's load that falls
+ * outside the solar daylight window into it, spread evenly across the day's
+ * daylight readings. `fraction` is 0–1 (0 = no change, 1 = shift all out-of-sun
+ * load into sunlit hours). Returns a new array of readings with adjusted `kwh`;
+ * timestamps and export are untouched. Days with no daylight readings are left
+ * unchanged. The total daily load is conserved.
+ */
+export function applyLoadShift(data, fraction) {
+  if (!data || data.length === 0) return data;
+  const f = Math.max(0, Math.min(1, fraction || 0));
+  if (f === 0) return data;
+
+  const byDay = new Map();
+  for (const r of data) {
+    const k = dateKey(r.timestamp);
+    if (!byDay.has(k)) byDay.set(k, []);
+    byDay.get(k).push(r);
+  }
+
+  const result = [];
+  for (const readings of byDay.values()) {
+    const copies = readings.map((r) => ({ ...r }));
+    const daylightIdx = [];
+    let shifted = 0;
+    copies.forEach((r, i) => {
+      if (isDaylight(r.timestamp)) {
+        daylightIdx.push(i);
+      } else {
+        const move = (r.kwh || 0) * f;
+        r.kwh = (r.kwh || 0) - move;
+        shifted += move;
+      }
+    });
+    if (daylightIdx.length > 0 && shifted > 0) {
+      const per = shifted / daylightIdx.length;
+      for (const i of daylightIdx) copies[i].kwh = (copies[i].kwh || 0) + per;
+    }
+    for (const r of copies) result.push(r);
+  }
+  return result;
+}
+
 /** Span of a dataset in days (>= 1). */
 function spanDays(data) {
   const first = data[0].timestamp.getTime();
@@ -514,7 +564,10 @@ function loanTerm(principal, annualRepayment, rateForYear, maxYears = 60) {
  * consumption and export for a given system size against the user's actual
  * load, plus a bank-loan view of the economics.
  *
- * opts: { sizeKw, capex, interestRate (decimal), greenLoan (bool) }.
+ * opts: { sizeKw, capex, interestRate (decimal), greenLoan (bool),
+ *         loadShiftPercent (0–100) }.
+ * loadShiftPercent moves that fraction of out-of-sun load into sunlit hours
+ * before modelling, which lifts self-consumption (issue #50).
  * Note that for every reading self-consumption + export equals generation, so
  * the per-day self and export columns always sum to the generation column.
  */
@@ -526,9 +579,13 @@ export function solarBreakdown(data, tariff, opts = {}) {
   const floatingRate = opts.interestRate ?? DEFAULT_LOAN_RATE;
   const greenLoan = !!opts.greenLoan;
   const exportRate = opts.exportRate ?? (tariff.solarExportRate || 0);
+  const loadShiftPercent = opts.loadShiftPercent ?? 0;
 
+  // Span (for annualising) comes from the original timestamps, which the load
+  // shift leaves untouched.
   const span = spanDays(data);
   const annualScale = 365 / span;
+  const modelData = applyLoadShift(data, loadShiftPercent / 100);
 
   const genSum = new Array(12).fill(0);
   const loadSum = new Array(12).fill(0);
@@ -540,7 +597,7 @@ export function solarBreakdown(data, tariff, opts = {}) {
   let selfCents = 0;
   let exportCents = 0;
 
-  for (const r of data) {
+  for (const r of modelData) {
     const m = r.timestamp.getMonth();
     const load = r.kwh || 0;
     const gen = generationForReading(r.timestamp, sizeKw);
@@ -593,6 +650,7 @@ export function solarBreakdown(data, tariff, opts = {}) {
     sizeKw,
     capex,
     exportRate,
+    loadShiftPercent,
     selfConsumptionSaving,
     exportEarning,
     annualSaving,

--- a/test/solar.test.js
+++ b/test/solar.test.js
@@ -3,6 +3,7 @@ import {
   batteryROI,
   solarROI,
   solarBreakdown,
+  applyLoadShift,
   discountedPayback,
   gridRateForReading,
   SOLAR_SCENARIOS,
@@ -286,5 +287,59 @@ describe("solarBreakdown", () => {
     const b = solarBreakdown(yearLoad, tariff, { sizeKw: 0.01, capex: 100000, interestRate: 0.1 });
     expect(b.loan.repaid).toBe(false);
     expect(b.loan.years).toBeNull();
+  });
+
+  it("load shifting lifts self-consumption savings without inventing generation", () => {
+    // Night-heavy load: most consumption is outside sunlit hours, so shifting it
+    // into the day lets solar self-consume it instead of exporting cheaply.
+    const nightHeavy = buildData("2025-01-01T00:00:00", 365, (h) =>
+      h >= 19 || h < 6 ? { kwh: 1.5, exportKwh: 0 } : { kwh: 0.1, exportKwh: 0 }
+    );
+    const base = solarBreakdown(nightHeavy, tariff, { sizeKw: 8.5, capex: 16500 });
+    const shifted = solarBreakdown(nightHeavy, tariff, { sizeKw: 8.5, capex: 16500, loadShiftPercent: 100 });
+
+    // Self-consumption (worth the full grid rate) rises, export falls.
+    expect(shifted.selfConsumptionSaving).toBeGreaterThan(base.selfConsumptionSaving);
+    expect(shifted.annualSaving).toBeGreaterThan(base.annualSaving);
+    // Generation is a property of the panels, not the load: it must not change.
+    expect(shifted.annualGenerationKwh).toBeCloseTo(base.annualGenerationKwh, 5);
+    expect(shifted.loadShiftPercent).toBe(100);
+  });
+});
+
+// ─── applyLoadShift ──────────────────────────────────────────
+
+describe("applyLoadShift", () => {
+  const oneDay = buildData("2025-01-15T00:00:00", 1, (h) =>
+    h >= 19 || h < 6 ? { kwh: 1.0, exportKwh: 0 } : { kwh: 0.2, exportKwh: 0 }
+  );
+
+  it("returns the input unchanged at 0%", () => {
+    expect(applyLoadShift(oneDay, 0)).toBe(oneDay);
+  });
+
+  it("conserves total daily load", () => {
+    const total = (d) => d.reduce((s, r) => s + r.kwh, 0);
+    const shifted = applyLoadShift(oneDay, 0.5);
+    expect(total(shifted)).toBeCloseTo(total(oneDay), 6);
+  });
+
+  it("moves out-of-sun load into daylight hours", () => {
+    const inDaylight = (d) =>
+      d.filter((r) => {
+        const h = r.timestamp.getHours();
+        return h >= 7 && h < 19; // comfortably inside the Jan window
+      }).reduce((s, r) => s + r.kwh, 0);
+    const before = inDaylight(oneDay);
+    const after = inDaylight(applyLoadShift(oneDay, 1));
+    expect(after).toBeGreaterThan(before);
+  });
+
+  it("clamps the fraction to [0, 1]", () => {
+    const total = (d) => d.reduce((s, r) => s + r.kwh, 0);
+    const overshoot = applyLoadShift(oneDay, 5);
+    expect(total(overshoot)).toBeCloseTo(total(oneDay), 6);
+    // No reading should go negative.
+    expect(overshoot.every((r) => r.kwh >= 0)).toBe(true);
   });
 });


### PR DESCRIPTION
Adds a "% load shifting" assumption to the solar maths breakdown that
moves a fraction of each day's out-of-sun load into sunlit hours, spread
evenly, lifting self-consumption. Includes a tooltip explaining the
concept with indicative percentages for common controls (dishwasher,
hot-water timer, daytime EV charging).

Closes #50

https://claude.ai/code/session_01TkJnE1BoHZZzpi9pFxe8M4